### PR TITLE
Add fr fr locale

### DIFF
--- a/src/docs/architecture/SideNav.vue
+++ b/src/docs/architecture/SideNav.vue
@@ -14,6 +14,7 @@
       <select class="form-control input-sm" v-model="$i18n.locale" style="width: auto">
         <option value="en-US">English</option>
         <option value="zh-CN">简体中文</option>
+        <option value="fr-FR">Français</option>
       </select>
     </div>
     <div class="nav-container">

--- a/src/docs/pages/I18n.vue
+++ b/src/docs/pages/I18n.vue
@@ -29,6 +29,7 @@ let appLocale = Object.assign({}, uivLocale, {
           <li>bg-BG</li>
           <li>cs-CZ</li>
           <li>en-US</li>
+          <li>fr-FR</li>
           <li>pt-BR</li>
           <li>zh-CN</li>
         </ul>

--- a/src/locale-docs/index.js
+++ b/src/locale-docs/index.js
@@ -3,12 +3,14 @@ import VueI18n from 'vue-i18n'
 
 import zhLocale from './lang/zh-CN'
 import enLocale from './lang/en-US'
+import frLocale from './lang/fr-FR'
 
 Vue.use(VueI18n)
 
 const messages = {
   'zh-CN': zhLocale,
-  'en-US': enLocale
+  'en-US': enLocale,
+  'fr-FR': frLocale
 }
 
 let defaultLocale = 'en-US'
@@ -27,9 +29,10 @@ const i18n = new VueI18n({
 
 // Hot updates
 if (module.hot) {
-  module.hot.accept(['./lang/en-US', './lang/zh-CN'], function () {
+  module.hot.accept(['./lang/en-US', './lang/zh-CN', './lang/fr-FR'], function () {
     i18n.setLocaleMessage('zh-CN', require('./lang/zh-CN').default)
     i18n.setLocaleMessage('en-US', require('./lang/en-US').default)
+    i18n.setLocaleMessage('fr-FR', require('./lang/fr-FR').default)
   })
 }
 

--- a/src/locale-docs/lang/fr-FR.js
+++ b/src/locale-docs/lang/fr-FR.js
@@ -1,0 +1,100 @@
+import uivLocale from './../../locale/lang/fr-FR'
+
+const docLocale = {
+  common: {
+    basicExample: 'Example Basique',
+    dynamicExample: 'Example Dynamique',
+    sampleCode: 'Code d\'exemple',
+    demoSource: 'Code Source de la démo',
+    source: 'Source',
+    note: 'Note',
+    props: 'Props',
+    slots: 'Slots',
+    events: 'Events',
+    name: 'Nom',
+    type: 'Type',
+    default: 'Défaut',
+    required: 'Requis',
+    description: 'Description',
+    params: 'Params'
+  },
+  menu: {
+    usage: 'Utilisation',
+    install: 'Installation',
+    i18n: 'I18n',
+    gettingStarted: 'Pour démarrer',
+    components: 'Composants',
+    alert: 'Alert',
+    carousel: 'Carousel',
+    collapse: 'Collapse',
+    datePicker: 'Date Picker',
+    dropdown: 'Dropdown',
+    modal: 'Modal',
+    pagination: 'Pagination',
+    popover: 'Popover',
+    progressBar: 'Progress Bar',
+    tabs: 'Tabs',
+    timePicker: 'Time Picker',
+    tooltip: 'Tooltip',
+    typeahead: 'Typeahead'
+  },
+  home: {
+    desc: 'Le composants <b>Bootstrap 3</b> implémentés avec <b>Vue 2</b>.',
+    codeOnGithub: 'Code sur Github',
+    gettingStarted: 'Pour démarrer',
+    lightWeight: 'Léger',
+    lightWeight1: '~ <b>14KB</b> Gziped',
+    lightWeight2: 'Uniques dépendances',
+    lightWeight3: '<b>Vue</b> & <b>Bootstrap CSS</b>',
+    compatible: 'Compatible',
+    compatible1: 'Testé avec les',
+    compatible2: '<b>Navigateurs modernes</b>',
+    compatible3: 'et <b>IE 9+</b>',
+    openSource: 'Open Source',
+    openSource1: 'Licence <b>MIT</b>',
+    openSource2: 'Façile à utiliser et gratuit',
+    openSource3: 'Ouvert aux collaborations!'
+  },
+  gettingStarted: {
+    dependencies: 'Dépendances',
+    supportedBrowsers: 'Navigateurs supportés',
+    supportedBrowsersDesc: 'Les composants et les directives sont testés avec les navigateurs suivants:',
+    usage: 'Utilisation',
+    usageDesc: 'uiv utilise l\'export UMD, ce qui vous permet de l\'utiliser avec ES6 / CommonJS / AMD / Browser.',
+    es6Sample: 'Exemple ES6',
+    browserSample: 'Exemple de markup'
+  },
+  install: {
+    viaCdn: 'Via CDN',
+    viaNpm: 'Via NPM',
+    viaNpmDesc: 'Il est recommandé d\'utiliser NPM pour gérer vos paquets et ES6 / Webpack pour développer vos projets Vue.'
+  },
+  i18n: {
+    basic: 'Utilisation basique',
+    basicDesc: 'Tous les composants uiv utilisent l\'anglais comme langue par défaut, vous pouvez utilise d\'autres langues, par exemple:',
+    basicDesc2: 'Comme vous pouvez le constater, vous pouvez définir vos propres traductions, créer votre propre <code>locale</code> et remplacer les valeurs par défaut.',
+    vueI18n: 'Utilisation avec Vue I18n',
+    vueI18nDesc: 'uiv est aussi compatible avec <a href="https://github.com/kazupon/vue-i18n">vue-i18n</a>.',
+    vueI18nDesc2: '<b>Note</b>: Vous devez fusionner les paquets langues uiv dans votre/vos application(s). Par exemple:',
+    supported: 'Langues supportées',
+    supportedSortBy: '(Affichées par ordre alphabétique)',
+    supportedContribute: 'Nous vous invitons à contribuer à l\'ajout de langues supplémentaire !'
+  },
+  alert: {
+    displayTime: 'Durée d\'affichage',
+    addAlertTime: 'Ajouter un Alert (avec durée)',
+    addAlert: 'Ajouter un Alert',
+    useWithCollapse: 'Utilisation avec Collapse',
+    showAlert: 'Afficher Alert'
+  },
+  carousel: {
+    toggleIndicators: 'Afficher/Masquer les puces',
+    toggleControls: 'Afficher/Masquer les contrôles',
+    pushSlide: 'Ajoute un Slide',
+    interval: 'Intervalle'
+  }
+}
+
+const locale = Object.assign({}, docLocale, uivLocale)
+
+export default locale

--- a/src/locale/lang/fr-FR.js
+++ b/src/locale/lang/fr-FR.js
@@ -1,0 +1,37 @@
+export default {
+  uiv: {
+    datePicker: {
+      clear: 'Effacer',
+      today: 'Aujourd\'hui',
+      month: 'Mois',
+      month1: 'Janvier',
+      month2: 'Février',
+      month3: 'Mars',
+      month4: 'Avril',
+      month5: 'Mai',
+      month6: 'Juin',
+      month7: 'Juillet',
+      month8: 'Août',
+      month9: 'Septembre',
+      month10: 'Octobre',
+      month11: 'Novembre',
+      month12: 'Décembre',
+      year: 'Année',
+      week1: 'Lun',
+      week2: 'Mar',
+      week3: 'Mer',
+      week4: 'Jeu',
+      week5: 'Ven',
+      week6: 'Sam',
+      week7: 'Dim'
+    },
+    timePicker: {
+      am: 'Matin',
+      pm: 'Après-midi'
+    },
+    modal: {
+      cancel: 'Annuler',
+      ok: 'OK'
+    }
+  }
+}


### PR DESCRIPTION
Fixes #65 

Changes proposed in this pull request:

- ADD `fr-FR` locale for the components
- ADD `fr-FR`locale for the documentation

I did run `npm run test` with no error:

`PhantomJS 2.1.1 (Mac OS X 0.0.0): Executed 167 of 167 SUCCESS (31.531 secs / 29.966 secs)
TOTAL: 167 SUCCESS`
 
@wxsms
