### PR TITLE
MINOR `example` in  french becomes `exemple`

### DIFF
--- a/src/locale-docs/lang/fr-FR.js
+++ b/src/locale-docs/lang/fr-FR.js
@@ -2,8 +2,8 @@ import uivLocale from './../../locale/lang/fr-FR'
 
 const docLocale = {
   common: {
-    basicExample: 'Example Basique',
-    dynamicExample: 'Example Dynamique',
+    basicExample: 'Exemple Basique',
+    dynamicExample: 'Exemple Dynamique',
     sampleCode: 'Code d\'exemple',
     demoSource: 'Code Source de la démo',
     source: 'Source',


### PR DESCRIPTION
Nothing fancy, just a small fix for 2 typos in the fr-FR translations