### PR TITLE
Round finished percentage

### DIFF
--- a/src/components/progressbar/ProgressBarStack.vue
+++ b/src/components/progressbar/ProgressBarStack.vue
@@ -52,7 +52,7 @@
     },
     computed: {
       finished () {
-        return (this.value - this.min) / (this.max - this.min) * 100
+        return Math.round((this.value - this.min) / (this.max - this.min) * 100)
       },
       computedClass () {
         return {


### PR DESCRIPTION
Fix #75 by rounding the calculated percentage value.
Prevents issues with the label caused by floating point rounding error for certain values of value

Fixes #75 

Changes proposed in this pull request:

- `Math.round()` the computed `finished` percentage in `ProgressBarStack.vue`
