### PR TITLE
ADD unit tests & docs for custom icons usage

### DIFF
--- a/docs/pages/components/DatePicker.md
+++ b/docs/pages/components/DatePicker.md
@@ -155,6 +155,18 @@ Change the starting day of the week. Support 0 (Sunday) ~ 6 (Saturday).
 <!-- date-picker-dropdown-example.vue -->
 ```
 
+## Custom icons
+
+```html
+<template>
+  <section>
+    <date-picker icon-control-left="glyphicon glyphicon-triangle-left" icon-control-right="glyphicon glyphicon-triangle-right"></date-picker>
+  </section>
+</template>
+<!-- date-picker-icons-example.vue -->
+```
+
+
 # API Reference
 
 ## [DatePicker.vue](https://github.com/wxsms/uiv/tree/master/src/components/datepicker/DatePicker.vue)

--- a/docs/pages/components/TimePicker.md
+++ b/docs/pages/components/TimePicker.md
@@ -122,6 +122,24 @@ All input methods are all disabled in readonly mode.
 <!-- time-picker-with-dropdown.vue -->
 ```
 
+## Custom icons
+
+```html
+<template>
+  <time-picker v-model="time" :show-meridian="false" icon-control-up="glyphicon glyphicon-plus" icon-control-down="glyphicon glyphicon-minus"></time-picker>
+</template>
+<script>
+  export default {
+    data () {
+      return {
+        time: new Date()
+      }
+    }
+  }
+</script>
+<!-- time-picker-icons-example.vue -->
+```
+
 
 # API Reference
 

--- a/test/unit/specs/DatePicker.spec.js
+++ b/test/unit/specs/DatePicker.spec.js
@@ -335,4 +335,12 @@ describe('DatePicker', () => {
     await vm.$nextTick()
     expect(_vm.$el.querySelector('.dropdown').className).not.contain('open')
   })
+
+  it('should be able to use custom icons', async () => {
+    let _vm = vm.$refs['date-picker-icons-example']
+    let $el = $(_vm.$el)
+    let $tr = $el.find('table:first-child tr:first-child')
+    expect($tr.find('td:first-child > .btn > i').get(0).className).to.contain('glyphicon-triangle-left')
+    expect($tr.find('td:last-child > .btn > i').get(0).className).to.contain('glyphicon-triangle-right')
+  })
 })

--- a/test/unit/specs/TimePicker.spec.js
+++ b/test/unit/specs/TimePicker.spec.js
@@ -257,4 +257,11 @@ describe('TimePicker', () => {
     expect(hourText.value).to.equal('08')
     expect(minutesText.value).to.equal('00')
   })
+
+  it('should be able to use custom icons', async () => {
+    let _vm = vm.$refs['time-picker-icons-example']
+    let $el = $(_vm.$el)
+    expect($el.find('tr:first-child .btn > i').get(0).className).to.contain('glyphicon-plus')
+    expect($el.find('tr:last-child .btn > i').get(0).className).to.contain('glyphicon-minus')
+  })
 })


### PR DESCRIPTION
For `DatePicker` & `TimePicker`…

While writing the docs, examples and test I also noticed that using a custom icon for the `Carousel` breaks the layout but this will be fixed via another issue...

@wxsms
