### PR TITLE
Refact tests

### DIFF
--- a/test/unit/specs/Affix.spec.js
+++ b/test/unit/specs/Affix.spec.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import $ from 'jquery'
 import Affix from '@src/components/affix/Affix.vue'
-import utils from './../utils'
+import utils from '../utils'
 
 describe('Affix', () => {
   let vm

--- a/test/unit/specs/Affix.spec.js
+++ b/test/unit/specs/Affix.spec.js
@@ -51,7 +51,7 @@ describe('Affix', () => {
   })
 
   it('should not toggle affix class if element is hidden', async () => {
-    let $body = $('html, body')
+    const $body = $('html, body')
     $body.css('height', '9999px')
     $el.css('display', 'none')
     await vm.$nextTick()

--- a/test/unit/specs/Alert.spec.js
+++ b/test/unit/specs/Alert.spec.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import $ from 'jquery'
 import Alert from '@src/components/alert/Alert.vue'
 import AlertDoc from '@docs/pages/components/Alert.md'
-import utils from './../utils'
+import utils from '../utils'
 
 const DEFAULT_ALERT_CLASS = 'alert-info'
 
@@ -27,7 +27,7 @@ describe('Alert', () => {
 
   it('should be able to add alert with no type', () => {
     const res = Vue.compile('<alert>{{ msg }}</alert>')
-    const localVm = new Vue({
+    const _vm = new Vue({
       data () {
         return {
           msg: 'This is a alert!'
@@ -37,12 +37,12 @@ describe('Alert', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     })
-    localVm.$mount()
-    const $alert = $(localVm.$el)
+    _vm.$mount()
+    const $alert = $(_vm.$el)
     expect($alert.hasClass('alert')).to.be.true
     expect($alert.hasClass(DEFAULT_ALERT_CLASS)).to.be.true
     $alert.remove()
-    localVm.$destroy()
+    _vm.$destroy()
   })
 
   it('should be able to dismiss alerts', async () => {

--- a/test/unit/specs/Alert.spec.js
+++ b/test/unit/specs/Alert.spec.js
@@ -26,8 +26,8 @@ describe('Alert', () => {
   }
 
   it('should be able to add alert with no type', () => {
-    let res = Vue.compile('<alert>{{ msg }}</alert>')
-    let vm = new Vue({
+    const res = Vue.compile('<alert>{{ msg }}</alert>')
+    const localVm = new Vue({
       data () {
         return {
           msg: 'This is a alert!'
@@ -37,47 +37,47 @@ describe('Alert', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     })
-    vm.$mount()
-    let $el = $(vm.$el)
-    expect($el.hasClass('alert')).to.be.true
-    expect($el.hasClass(DEFAULT_ALERT_CLASS)).to.be.true
-    $el.remove()
-    vm.$destroy()
+    localVm.$mount()
+    const $alert = $(localVm.$el)
+    expect($alert.hasClass('alert')).to.be.true
+    expect($alert.hasClass(DEFAULT_ALERT_CLASS)).to.be.true
+    $alert.remove()
+    localVm.$destroy()
   })
 
   it('should be able to dismiss alerts', async () => {
-    let _$el = $(vm.$refs['alert-dismissible'].$el)
-    let alert = _$el.find('.alert')
-    expect(alert.length).to.equal(1)
-    let closedBtn = alert.find('button.close')
-    closedBtn.click()
+    const _$el = $(vm.$refs['alert-dismissible'].$el)
+    const $alert = _$el.find('.alert')
+    expect($alert.length).to.equal(1)
+    const closeBtn = $alert.find('button.close').get(0)
+    utils.triggerEvent(closeBtn, 'click')
     await vm.$nextTick()
     expect(_$el.find('.alert').length).to.equal(0)
   })
 
   it('should be able to add dismissible alerts', async () => {
-    let _$el = $(vm.$refs['alert-dismissible'].$el)
-    let before = getDefaultAlertLength()
-    let addAlertBtn = _$el.find('.btn-primary')
-    addAlertBtn.click()
+    const _$el = $(vm.$refs['alert-dismissible'].$el)
+    const alertInstancesBefore = getDefaultAlertLength()
+    const addAlertBtn = _$el.find('.btn-primary').get(0)
+    utils.triggerEvent(addAlertBtn, 'click')
     await vm.$nextTick()
-    let after = getDefaultAlertLength()
-    expect(after).to.equal(before + 1)
+    const alertInstancesAfter = getDefaultAlertLength()
+    expect(alertInstancesAfter).to.equal(alertInstancesBefore + 1)
   })
 
   it('should be able to add auto dismiss alerts', async () => {
-    let _vm = vm.$refs['alert-auto-dismissing']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['alert-auto-dismissing']
+    const _$el = $(_vm.$el)
     _vm.duration = 1000
     await vm.$nextTick()
-    let before = getDefaultAlertLength()
-    let addAlertBtn = _$el.find('.btn-primary')
-    addAlertBtn.click()
+    const alertInstancesBefore = getDefaultAlertLength()
+    const addAlertBtn = _$el.find('.btn-primary').get(0)
+    utils.triggerEvent(addAlertBtn, 'click')
     await vm.$nextTick()
-    let after = getDefaultAlertLength()
-    expect(after).to.equal(before + 1)
+    const alertInstancesAfter = getDefaultAlertLength()
+    expect(alertInstancesAfter).to.equal(alertInstancesBefore + 1)
     await utils.sleep(_vm.duration + 200)
-    let _after = getDefaultAlertLength()
-    expect(_after).to.equal(before)
+    const alertInstancesAfterDelay = getDefaultAlertLength()
+    expect(alertInstancesAfterDelay).to.equal(alertInstancesBefore)
   })
 })

--- a/test/unit/specs/Breadcrumbs.spec.js
+++ b/test/unit/specs/Breadcrumbs.spec.js
@@ -63,7 +63,7 @@ describe('Breadcrumbs', () => {
 
   it('should not auto active last item if using active prop', () => {
     const res = Vue.compile('<breadcrumbs :items="items"></breadcrumbs>')
-    const localVm = new Vue({
+    const _vm = new Vue({
       data () {
         return {
           items: [{text: 'test', href: '#', active: false, key: 0}]
@@ -72,7 +72,7 @@ describe('Breadcrumbs', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    const $breadcrumb = $(localVm.$el)
+    const $breadcrumb = $(_vm.$el)
     const $li = $('li', $breadcrumb)
     expect($li.length).to.equal(1)
     const $link1 = $('a', $li)
@@ -80,18 +80,18 @@ describe('Breadcrumbs', () => {
     expect($link1.attr('target')).to.equal('_self')
     expect($link1.text()).to.equal('test')
     expect($breadcrumb.find('.active').length).to.equal(0)
-    localVm.$destroy()
+    _vm.$destroy()
   })
 
   it('should render nothing if no children and items', async () => {
     const res = Vue.compile('<breadcrumbs></breadcrumbs>')
-    const localVm = new Vue({
+    const _vm = new Vue({
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    const $breadcrumb = $(localVm.$el)
-    await localVm.$nextTick()
+    const $breadcrumb = $(_vm.$el)
+    await _vm.$nextTick()
     expect($breadcrumb.children().length).to.equal(0)
-    localVm.$destroy()
+    _vm.$destroy()
   })
 })

--- a/test/unit/specs/Breadcrumbs.spec.js
+++ b/test/unit/specs/Breadcrumbs.spec.js
@@ -7,7 +7,7 @@ describe('Breadcrumbs', () => {
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(BreadcrumbsDoc)
+    const Constructor = Vue.extend(BreadcrumbsDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -17,50 +17,53 @@ describe('Breadcrumbs', () => {
     $el.remove()
   })
 
-  it('should be able to render with items data', () => {
-    let b = $el.find('.breadcrumb').get(0)
-    expect(b.querySelectorAll('li').length).to.equal(3)
-    let nav1 = b.querySelectorAll('li a')[0]
-    expect(nav1.getAttribute('href')).to.equal('#')
-    expect(nav1.getAttribute('target')).to.equal('_self')
-    expect(nav1.textContent).to.equal('Home')
-    let nav2 = b.querySelectorAll('li a')[1]
-    expect(nav2.getAttribute('href')).to.equal('#')
-    expect(nav2.getAttribute('target')).to.equal('_self')
-    expect(nav2.textContent).to.equal('Library')
-    let nav3 = b.querySelectorAll('li')[2]
-    expect(nav3.className).to.contain('active')
-    expect(nav3.querySelector('a')).not.exist
-    expect(nav3.textContent).to.equal('Data')
+  it('should be able to render with item data', () => {
+    const $breadcrumb = $($el.find('.breadcrumb').get(0))
+    const $li = $('li', $breadcrumb)
+    expect($li.length).to.equal(3)
+    const $link1 = $('a', $li.first())
+    expect($link1.attr('href')).to.equal('#')
+    expect($link1.attr('target')).to.equal('_self')
+    expect($link1.text()).to.equal('Home')
+    const $link2 = $('a', $li.get(1))
+    expect($link2.attr('href')).to.equal('#')
+    expect($link2.attr('target')).to.equal('_self')
+    expect($link2.text()).to.equal('Library')
+    const $nav3 = $li.last()
+    expect($nav3.attr('class')).to.contain('active')
+    expect($nav3.find('a').length).to.equal(0)
+    expect($nav3.text()).to.equal('Data')
   })
 
   it('should be able to render with <breadcrumb-item>', () => {
-    let b = $el.find('.breadcrumb').get(1)
-    expect(b.querySelectorAll('li').length).to.equal(3)
-    let nav1 = b.querySelectorAll('li a')[0]
-    expect(nav1.getAttribute('href')).to.equal('#')
-    expect(nav1.getAttribute('target')).to.equal('_self')
-    expect(nav1.querySelector('b')).to.exist
-    expect(nav1.querySelector('b').textContent).to.equal('Home')
-    let nav2 = b.querySelectorAll('li a')[1]
-    expect(nav2.getAttribute('href')).to.equal('#')
-    expect(nav2.getAttribute('target')).to.equal('_self')
-    expect(nav2.textContent).to.equal('Library')
-    let nav3 = b.querySelectorAll('li')[2]
-    expect(nav3.className).to.contain('active')
-    expect(nav3.querySelector('a')).not.exist
-    expect(nav3.textContent).to.equal('Data')
+    const $breadcrumb = $($el.find('.breadcrumb').get(1))
+    const $li = $('li', $breadcrumb)
+    expect($li.length).to.equal(3)
+    const $link1 = $('a', $li.first())
+    expect($link1.attr('href')).to.equal('#')
+    expect($link1.attr('target')).to.equal('_self')
+    const $b = $link1.find('b')
+    expect($b.length).to.equal(1)
+    expect($b.text()).to.equal('Home')
+    const $link2 = $('a', $li.get(1))
+    expect($link2.attr('href')).to.equal('#')
+    expect($link2.attr('target')).to.equal('_self')
+    expect($link2.text()).to.equal('Library')
+    const $nav3 = $li.last()
+    expect($nav3.attr('class')).to.contain('active')
+    expect($nav3.find('a').length).to.equal(0)
+    expect($nav3.text()).to.equal('Data')
   })
 
   it('should be able to render router-link', () => {
-    let b = $el.find('.breadcrumb').get(2)
-    let nav1 = b.querySelectorAll('li a')[0]
-    expect(nav1.getAttribute('href')).to.equal('#router-link') // router-link mock
+    const $breadcrumb = $($el.find('.breadcrumb').get(2))
+    const $nav1 = $breadcrumb.find('li a').first()
+    expect($nav1.attr('href')).to.equal('#router-link') // router-link mock
   })
 
   it('should not auto active last item if using active prop', () => {
-    let res = Vue.compile('<breadcrumbs :items="items"></breadcrumbs>')
-    let vm = new Vue({
+    const res = Vue.compile('<breadcrumbs :items="items"></breadcrumbs>')
+    const localVm = new Vue({
       data () {
         return {
           items: [{text: 'test', href: '#', active: false, key: 0}]
@@ -69,25 +72,26 @@ describe('Breadcrumbs', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el)
-    expect(vm.$el.querySelectorAll('li').length).to.equal(1)
-    let nav1 = vm.$el.querySelectorAll('li a')[0]
-    expect(nav1.getAttribute('href')).to.equal('#')
-    expect(nav1.getAttribute('target')).to.equal('_self')
-    expect(nav1.textContent).to.equal('test')
-    expect($el.find('.active').length).to.equal(0)
-    vm.$destroy()
+    const $breadcrumb = $(localVm.$el)
+    const $li = $('li', $breadcrumb)
+    expect($li.length).to.equal(1)
+    const $link1 = $('a', $li)
+    expect($link1.attr('href')).to.equal('#')
+    expect($link1.attr('target')).to.equal('_self')
+    expect($link1.text()).to.equal('test')
+    expect($breadcrumb.find('.active').length).to.equal(0)
+    localVm.$destroy()
   })
 
   it('should render nothing if no children and items', async () => {
-    let res = Vue.compile('<breadcrumbs></breadcrumbs>')
-    let vm = new Vue({
+    const res = Vue.compile('<breadcrumbs></breadcrumbs>')
+    const localVm = new Vue({
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el)
-    await vm.$nextTick()
-    expect($el.children().length).to.equal(0)
-    vm.$destroy()
+    const $breadcrumb = $(localVm.$el)
+    await localVm.$nextTick()
+    expect($breadcrumb.children().length).to.equal(0)
+    localVm.$destroy()
   })
 })

--- a/test/unit/specs/Btn.spec.js
+++ b/test/unit/specs/Btn.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import $ from 'jquery'
-import utils from './../utils'
+import utils from '../utils'
 import BtnDoc from '@docs/pages/components/Btn.md'
 import Btn from '@src/components/button/Btn'
 
@@ -103,7 +103,7 @@ describe('Btn', () => {
 
   it('should emit click event', async () => {
     const res = Vue.compile('<btn @click="onClick">{{ msg }}</btn>')
-    const localVm = new Vue({
+    const _vm = new Vue({
       data () {
         return {
           msg: 'test'
@@ -118,16 +118,16 @@ describe('Btn', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await localVm.$nextTick()
-    expect(localVm.msg).to.equal('test')
-    utils.triggerEvent(localVm.$el, 'click')
-    await localVm.$nextTick()
-    expect(localVm.msg).to.equal('clicked')
+    await _vm.$nextTick()
+    expect(_vm.msg).to.equal('test')
+    utils.triggerEvent(_vm.$el, 'click')
+    await _vm.$nextTick()
+    expect(_vm.msg).to.equal('clicked')
   })
 
   it('should not emit click event while disabled', async () => {
     const res = Vue.compile('<btn disabled @click="onClick">{{ msg }}</btn>')
-    const localVm = new Vue({
+    const _vm = new Vue({
       data () {
         return {
           msg: 'test'
@@ -142,11 +142,11 @@ describe('Btn', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await localVm.$nextTick()
-    expect(localVm.msg).to.equal('test')
-    utils.triggerEvent(localVm.$el, 'click')
-    await localVm.$nextTick()
-    expect(localVm.msg).to.equal('test')
+    await _vm.$nextTick()
+    expect(_vm.msg).to.equal('test')
+    utils.triggerEvent(_vm.$el, 'click')
+    await _vm.$nextTick()
+    expect(_vm.msg).to.equal('test')
   })
 
   it('should be able to render checkbox btn', async () => {
@@ -246,14 +246,14 @@ describe('Btn', () => {
 
   it('should be able to render as justified', async () => {
     const res = Vue.compile('<btn justified>test</btn>')
-    const localVm = new Vue({
+    const _vm = new Vue({
       components: {Btn},
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await localVm.$nextTick()
-    expect(localVm.$el.className).to.contain('btn-group')
-    const btn = localVm.$el.querySelector('.btn')
+    await _vm.$nextTick()
+    expect(_vm.$el.className).to.contain('btn-group')
+    const btn = _vm.$el.querySelector('.btn')
     expect(btn).to.exist
     expect(btn.innerText).to.equal('test')
   })

--- a/test/unit/specs/Btn.spec.js
+++ b/test/unit/specs/Btn.spec.js
@@ -9,7 +9,7 @@ describe('Btn', () => {
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(BtnDoc)
+    const Constructor = Vue.extend(BtnDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -20,80 +20,90 @@ describe('Btn', () => {
   })
 
   it('should be able to render btn types', () => {
-    let _$el = $(vm.$refs['btn-examples'].$el)
-    expect(_$el.find('button.btn').length).to.equal(7)
+    const $cont = $(vm.$refs['btn-examples'].$el)
+    const $btns = $('button.btn', $cont)
+    expect($btns.length).to.equal(7)
     // all render as type=button
-    expect(_$el.find('[type=button]').length).to.equal(7)
-    expect(_$el.find('.btn').get(0).className).to.contain('btn-default')
-    expect(_$el.find('.btn').get(1).className).to.contain('btn-primary')
-    expect(_$el.find('.btn').get(2).className).to.contain('btn-success')
-    expect(_$el.find('.btn').get(3).className).to.contain('btn-info')
-    expect(_$el.find('.btn').get(4).className).to.contain('btn-warning')
-    expect(_$el.find('.btn').get(5).className).to.contain('btn-danger')
-    expect(_$el.find('.btn').get(6).className).to.contain('btn-link')
+    const $btnsType = $('[type=button]', $cont)
+    expect($btnsType.length).to.equal(7)
+    // classnames
+    expect($btns.get(0).className).to.contain('btn-default')
+    expect($btns.get(1).className).to.contain('btn-primary')
+    expect($btns.get(2).className).to.contain('btn-success')
+    expect($btns.get(3).className).to.contain('btn-info')
+    expect($btns.get(4).className).to.contain('btn-warning')
+    expect($btns.get(5).className).to.contain('btn-danger')
+    expect($btns.get(6).className).to.contain('btn-link')
   })
 
   it('should be able to render link btn', () => {
-    let _$el = $(vm.$refs['btn-links'].$el)
-    expect(_$el.find('button').length).to.equal(0)
-    expect(_$el.find('a.btn').length).to.equal(4)
+    const $btnLinks = $(vm.$refs['btn-links'].$el)
+    expect($('button', $btnLinks).length).to.equal(0)
+    expect($('a.btn', $btnLinks).length).to.equal(4)
     // native links
-    expect(_$el.find('.btn').get(0).className).to.contain('btn-default')
-    expect(_$el.find('.btn').get(0).getAttribute('href')).to.equal('#')
-    expect(_$el.find('.btn').get(0).getAttribute('role')).to.equal('button')
-    expect(_$el.find('.btn').get(1).className).to.contain('btn-primary')
-    expect(_$el.find('.btn').get(1).getAttribute('href')).to.equal('#')
-    expect(_$el.find('.btn').get(1).getAttribute('role')).to.equal('button')
+    const $btn = $('.btn', $btnLinks)
+    const $btn0 = $($btn.get(0))
+    expect($btn0.attr('class')).to.contain('btn-default')
+    expect($btn0.attr('href')).to.equal('#')
+    expect($btn0.attr('role')).to.equal('button')
+    const $btn1 = $($btn.get(1))
+    expect($btn1.attr('class')).to.contain('btn-primary')
+    expect($btn1.attr('href')).to.equal('#')
+    expect($btn1.attr('role')).to.equal('button')
     // router links
-    expect(_$el.find('.btn').get(2).className).to.contain('btn-default')
-    expect(_$el.find('.btn').get(2).getAttribute('href')).to.equal('#router-link')
-    expect(_$el.find('.btn').get(2).getAttribute('role')).to.equal('button')
-    expect(_$el.find('.btn').get(3).className).to.contain('btn-primary')
-    expect(_$el.find('.btn').get(3).getAttribute('href')).to.equal('#router-link')
-    expect(_$el.find('.btn').get(3).getAttribute('role')).to.equal('button')
+    const $btn2 = $($btn.get(2))
+    expect($btn2.attr('class')).to.contain('btn-default')
+    expect($btn2.attr('href')).to.equal('#router-link')
+    expect($btn2.attr('role')).to.equal('button')
+    const $btn3 = $($btn.get(3))
+    expect($btn3.attr('class')).to.contain('btn-primary')
+    expect($btn3.attr('href')).to.equal('#router-link')
+    expect($btn3.attr('role')).to.equal('button')
   })
 
   it('should be able to render different size btn', () => {
-    let _$el = $(vm.$refs['btn-sizes'].$el)
-    expect(_$el.find('.btn').length).to.equal(8)
-    expect(_$el.find('.btn').get(0).className).to.contain('btn-lg')
-    expect(_$el.find('.btn').get(1).className).to.contain('btn-lg')
-    expect(_$el.find('.btn').get(4).className).to.contain('btn-sm')
-    expect(_$el.find('.btn').get(5).className).to.contain('btn-sm')
-    expect(_$el.find('.btn').get(6).className).to.contain('btn-xs')
-    expect(_$el.find('.btn').get(7).className).to.contain('btn-xs')
+    const $btnSizes = $(vm.$refs['btn-sizes'].$el)
+    const $btn = $('.btn', $btnSizes)
+    expect($btn.length).to.equal(8)
+    expect($btn.get(0).className).to.contain('btn-lg')
+    expect($btn.get(1).className).to.contain('btn-lg')
+    expect($btn.get(4).className).to.contain('btn-sm')
+    expect($btn.get(5).className).to.contain('btn-sm')
+    expect($btn.get(6).className).to.contain('btn-xs')
+    expect($btn.get(7).className).to.contain('btn-xs')
   })
 
   it('should be able to render block level btn', () => {
-    let _$el = $(vm.$refs['btn-block'].$el)
-    expect(_$el.find('.btn.btn-block').length).to.equal(2)
+    const $btnBlock = $(vm.$refs['btn-block'].$el)
+    expect($btnBlock.find('.btn.btn-block').length).to.equal(2)
   })
 
   it('should be able to render active btn', () => {
-    let _$el = $(vm.$refs['btn-active'].$el)
-    expect(_$el.find('.btn.active').length).to.equal(4)
-    expect(_$el.find('button.active').length).to.equal(2)
-    expect(_$el.find('a.active').length).to.equal(2)
+    const $btnActive = $(vm.$refs['btn-active'].$el)
+    expect($btnActive.find('.btn.active').length).to.equal(4)
+    expect($btnActive.find('button.active').length).to.equal(2)
+    expect($btnActive.find('a.active').length).to.equal(2)
   })
 
   it('should be able to render disabled btn', () => {
-    let _$el = $(vm.$refs['btn-disabled'].$el)
-    expect(_$el.find('.btn').length).to.equal(4)
-    expect(_$el.find('.btn.disabled').length).to.equal(4)
-    expect(_$el.find('.btn[disabled]').length).to.equal(2)
+    const $btnDisabled = $(vm.$refs['btn-disabled'].$el)
+    expect($btnDisabled.find('.btn').length).to.equal(4)
+    expect($btnDisabled.find('.btn.disabled').length).to.equal(4)
+    expect($btnDisabled.find('.btn[disabled]').length).to.equal(2)
   })
 
   it('should not response on disabled link btn click', async () => {
-    let _$el = $(vm.$refs['btn-disabled'].$el)
+    const $btnDisabled = $(vm.$refs['btn-disabled'].$el)
     expect(window.location.hash).to.equal('')
-    _$el.find('a.btn').get(0).click()
+    const btn = $btnDisabled.find('a.btn').get(0)
+    utils.triggerEvent(btn, 'click')
     await vm.$nextTick()
     expect(window.location.hash).to.equal('')
   })
 
   it('should emit click event', async () => {
-    let res = Vue.compile('<btn @click="onClick">{{ msg }}</btn>')
-    let vm = new Vue({
+    const res = Vue.compile('<btn @click="onClick">{{ msg }}</btn>')
+    const localVm = new Vue({
       data () {
         return {
           msg: 'test'
@@ -108,16 +118,16 @@ describe('Btn', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await vm.$nextTick()
-    expect(vm.msg).to.equal('test')
-    utils.triggerEvent(vm.$el, 'click')
-    await vm.$nextTick()
-    expect(vm.msg).to.equal('clicked')
+    await localVm.$nextTick()
+    expect(localVm.msg).to.equal('test')
+    utils.triggerEvent(localVm.$el, 'click')
+    await localVm.$nextTick()
+    expect(localVm.msg).to.equal('clicked')
   })
 
   it('should not emit click event while disabled', async () => {
-    let res = Vue.compile('<btn disabled @click="onClick">{{ msg }}</btn>')
-    let vm = new Vue({
+    const res = Vue.compile('<btn disabled @click="onClick">{{ msg }}</btn>')
+    const localVm = new Vue({
       data () {
         return {
           msg: 'test'
@@ -132,118 +142,118 @@ describe('Btn', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await vm.$nextTick()
-    expect(vm.msg).to.equal('test')
-    utils.triggerEvent(vm.$el, 'click')
-    await vm.$nextTick()
-    expect(vm.msg).to.equal('test')
+    await localVm.$nextTick()
+    expect(localVm.msg).to.equal('test')
+    utils.triggerEvent(localVm.$el, 'click')
+    await localVm.$nextTick()
+    expect(localVm.msg).to.equal('test')
   })
 
   it('should be able to render checkbox btn', async () => {
-    let _$el = $(vm.$refs['btn-input-checkbox'].$el)
+    const $btnInputCheckbox = $(vm.$refs['btn-input-checkbox'].$el)
     await vm.$nextTick()
-    expect(_$el.find('label.btn').length).to.equal(4)
-    expect(_$el.find('label.btn > input[type=checkbox]').length).to.equal(4)
+    expect($btnInputCheckbox.find('label.btn').length).to.equal(4)
+    expect($btnInputCheckbox.find('label.btn > input[type=checkbox]').length).to.equal(4)
     // active first one
-    expect(_$el.find('label.btn.active').length).to.equal(1)
-    expect(_$el.find('label.btn > input[type=checkbox]').get(0).checked).to.be.true
-    expect(_$el.find('label.btn').get(0).className).to.contain('active')
+    expect($btnInputCheckbox.find('label.btn.active').length).to.equal(1)
+    expect($btnInputCheckbox.find('label.btn > input[type=checkbox]').get(0).checked).to.be.true
+    expect($btnInputCheckbox.find('label.btn').get(0).className).to.contain('active')
     // disabled last one
-    expect(_$el.find('label.btn.disabled').length).to.equal(1)
-    expect(_$el.find('label.btn.disabled > input[disabled]').length).to.equal(1)
-    expect(_$el.find('label.btn').get(3).className).to.contain('disabled')
+    expect($btnInputCheckbox.find('label.btn.disabled').length).to.equal(1)
+    expect($btnInputCheckbox.find('label.btn.disabled > input[disabled]').length).to.equal(1)
+    expect($btnInputCheckbox.find('label.btn').get(3).className).to.contain('disabled')
   })
 
   it('should be able to select checkbox btn', async () => {
-    let _vm = vm.$refs['btn-input-checkbox']
-    let _$el = $(_vm.$el)
+    const $btnInputCheckbox = vm.$refs['btn-input-checkbox']
+    $el = $($btnInputCheckbox.$el)
     await vm.$nextTick()
     // phantomjs won't response on label click
-    utils.triggerEvent(_$el.find('label.btn > input').get(1), 'change')
+    utils.triggerEvent($el.find('label.btn > input').get(1), 'change')
     await vm.$nextTick()
     // active second one
-    expect(_$el.find('label.btn.active').length).to.equal(2)
-    expect(_$el.find('label.btn > input[type=checkbox]').get(0).checked).to.be.true
-    expect(_$el.find('label.btn > input[type=checkbox]').get(1).checked).to.be.true
-    expect(_$el.find('label.btn > input[type=checkbox]').get(3).checked).to.be.false
-    expect(_$el.find('label.btn').get(1).className).to.contain('active')
+    expect($el.find('label.btn.active').length).to.equal(2)
+    expect($el.find('label.btn > input[type=checkbox]').get(0).checked).to.be.true
+    expect($el.find('label.btn > input[type=checkbox]').get(1).checked).to.be.true
+    expect($el.find('label.btn > input[type=checkbox]').get(3).checked).to.be.false
+    expect($el.find('label.btn').get(1).className).to.contain('active')
     // model change
-    expect(_vm.model.length).to.equal(2)
-    expect(_vm.model.indexOf('1')).to.be.at.least(0)
-    expect(_vm.model.indexOf('2')).to.be.at.least(0)
+    expect($btnInputCheckbox.model.length).to.equal(2)
+    expect($btnInputCheckbox.model.indexOf('1')).to.be.at.least(0)
+    expect($btnInputCheckbox.model.indexOf('2')).to.be.at.least(0)
   })
 
   it('should be able to un-select checkbox btn', async () => {
-    let _vm = vm.$refs['btn-input-checkbox']
-    let _$el = $(_vm.$el)
+    const $btnInputCheckbox = vm.$refs['btn-input-checkbox']
+    $el = $($btnInputCheckbox.$el)
     await vm.$nextTick()
     // phantomjs won't response on label click
-    utils.triggerEvent(_$el.find('label.btn > input').get(0), 'change')
+    utils.triggerEvent($el.find('label.btn > input').get(0), 'change')
     await vm.$nextTick()
-    expect(_$el.find('label.btn.active').length).to.equal(0)
+    expect($el.find('label.btn.active').length).to.equal(0)
     // model change
-    expect(_vm.model.length).to.equal(0)
+    expect($btnInputCheckbox.model.length).to.equal(0)
   })
 
   it('should be able to render radio btn', async () => {
-    let _$el = $(vm.$refs['btn-input-radio'].$el)
+    const $btnInputRadio = $(vm.$refs['btn-input-radio'].$el)
     await vm.$nextTick()
-    expect(_$el.find('label.btn').length).to.equal(4)
-    expect(_$el.find('label.btn > input[type=radio]').length).to.equal(4)
+    expect($btnInputRadio.find('label.btn').length).to.equal(4)
+    expect($btnInputRadio.find('label.btn > input[type=radio]').length).to.equal(4)
     // active first one
-    expect(_$el.find('label.btn.active').length).to.equal(1)
-    expect(_$el.find('label.btn > input[type=radio]').get(0).checked).to.be.true
-    expect(_$el.find('label.btn').get(0).className).to.contain('active')
+    expect($btnInputRadio.find('label.btn.active').length).to.equal(1)
+    expect($btnInputRadio.find('label.btn > input[type=radio]').get(0).checked).to.be.true
+    expect($btnInputRadio.find('label.btn').get(0).className).to.contain('active')
     // disabled last one
-    expect(_$el.find('label.btn.disabled').length).to.equal(1)
-    expect(_$el.find('label.btn.disabled > input[disabled]').length).to.equal(1)
-    expect(_$el.find('label.btn').get(3).className).to.contain('disabled')
+    expect($btnInputRadio.find('label.btn.disabled').length).to.equal(1)
+    expect($btnInputRadio.find('label.btn.disabled > input[disabled]').length).to.equal(1)
+    expect($btnInputRadio.find('label.btn').get(3).className).to.contain('disabled')
   })
 
   it('should be able to select radio btn', async () => {
-    let _vm = vm.$refs['btn-input-radio']
-    let _$el = $(_vm.$el)
+    const $btnInputRadio = vm.$refs['btn-input-radio']
+    $el = $($btnInputRadio.$el)
     await vm.$nextTick()
     // phantomjs won't response on label click
-    utils.triggerEvent(_$el.find('label.btn > input').get(1), 'change')
+    utils.triggerEvent($el.find('label.btn > input').get(1), 'change')
     await vm.$nextTick()
     // active second one
-    expect(_$el.find('label.btn.active').length).to.equal(1)
-    expect(_$el.find('label.btn > input[type=radio]').get(0).checked).to.be.false
-    expect(_$el.find('label.btn > input[type=radio]').get(1).checked).to.be.true
-    expect(_$el.find('label.btn > input[type=radio]').get(3).checked).to.be.false
-    expect(_$el.find('label.btn').get(1).className).to.contain('active')
+    expect($el.find('label.btn.active').length).to.equal(1)
+    expect($el.find('label.btn > input[type=radio]').get(0).checked).to.be.false
+    expect($el.find('label.btn > input[type=radio]').get(1).checked).to.be.true
+    expect($el.find('label.btn > input[type=radio]').get(3).checked).to.be.false
+    expect($el.find('label.btn').get(1).className).to.contain('active')
     // model change
-    expect(_vm.model).to.equal('2')
+    expect($btnInputRadio.model).to.equal('2')
   })
 
   it('should not be able to un-select radio btn', async () => {
-    let _vm = vm.$refs['btn-input-radio']
-    let _$el = $(_vm.$el)
+    const $btnInputRadio = vm.$refs['btn-input-radio']
+    $el = $($btnInputRadio.$el)
     await vm.$nextTick()
     // phantomjs won't response on label click
-    utils.triggerEvent(_$el.find('label.btn > input').get(0), 'change')
+    utils.triggerEvent($el.find('label.btn > input').get(0), 'change')
     await vm.$nextTick()
     // active second one
-    expect(_$el.find('label.btn.active').length).to.equal(1)
-    expect(_$el.find('label.btn > input[type=radio]').get(0).checked).to.be.true
-    expect(_$el.find('label.btn > input[type=radio]').get(1).checked).to.be.false
-    expect(_$el.find('label.btn > input[type=radio]').get(3).checked).to.be.false
-    expect(_$el.find('label.btn').get(0).className).to.contain('active')
+    expect($el.find('label.btn.active').length).to.equal(1)
+    expect($el.find('label.btn > input[type=radio]').get(0).checked).to.be.true
+    expect($el.find('label.btn > input[type=radio]').get(1).checked).to.be.false
+    expect($el.find('label.btn > input[type=radio]').get(3).checked).to.be.false
+    expect($el.find('label.btn').get(0).className).to.contain('active')
     // model change
-    expect(_vm.model).to.equal('1')
+    expect($btnInputRadio.model).to.equal('1')
   })
 
   it('should be able to render as justified', async () => {
-    let res = Vue.compile('<btn justified>test</btn>')
-    let vm = new Vue({
+    const res = Vue.compile('<btn justified>test</btn>')
+    const localVm = new Vue({
       components: {Btn},
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await vm.$nextTick()
-    expect(vm.$el.className).to.contain('btn-group')
-    let btn = vm.$el.querySelector('.btn')
+    await localVm.$nextTick()
+    expect(localVm.$el.className).to.contain('btn-group')
+    const btn = localVm.$el.querySelector('.btn')
     expect(btn).to.exist
     expect(btn.innerText).to.equal('test')
   })

--- a/test/unit/specs/BtnGroup.spec.js
+++ b/test/unit/specs/BtnGroup.spec.js
@@ -18,19 +18,19 @@ describe('BtnGroup', () => {
   })
 
   it('should be able to render btn group', () => {
-    let _$el = $(vm.$refs['btn-group-example'].$el)
+    const _$el = $(vm.$refs['btn-group-example'].$el)
     expect(_$el.find('.btn-group').length).to.equal(1)
     expect(_$el.find('.btn-group > .btn').length).to.equal(3)
   })
 
   it('should be able to render btn toolbar', () => {
-    let _$el = $(vm.$refs['btn-group-toolbar'].$el)
+    const _$el = $(vm.$refs['btn-group-toolbar'].$el)
     expect(_$el.find('.btn-toolbar').length).to.equal(1)
     expect(_$el.find('.btn-toolbar > .btn-group').length).to.equal(3)
   })
 
   it('should be able to render different sizes', () => {
-    let _$el = $(vm.$refs['btn-group-sizes'].$el)
+    const _$el = $(vm.$refs['btn-group-sizes'].$el)
     expect(_$el.find('.btn-group').length).to.equal(4)
     expect(_$el.find('.btn-group').get(0).className).to.contain('btn-group-lg')
     expect(_$el.find('.btn-group').get(2).className).to.contain('btn-group-sm')
@@ -38,18 +38,18 @@ describe('BtnGroup', () => {
   })
 
   it('should be able to render nesting btn group', () => {
-    let _$el = $(vm.$refs['btn-group-nesting'].$el)
+    const _$el = $(vm.$refs['btn-group-nesting'].$el)
     expect(_$el.find('.btn-group > .btn').length).to.equal(4)
     expect(_$el.find('.btn-group > .btn-group').length).to.equal(1)
   })
 
   it('should be able to render vertical btn group', () => {
-    let _$el = $(vm.$refs['btn-group-vertical'].$el)
+    const _$el = $(vm.$refs['btn-group-vertical'].$el)
     expect(_$el.find('.btn-group-vertical').length).to.equal(1)
   })
 
   it('should be able to render justified btn group', async () => {
-    let _$el = $(vm.$refs['btn-group-justified'].$el)
+    const _$el = $(vm.$refs['btn-group-justified'].$el)
     await vm.$nextTick()
     expect(_$el.find('.btn-group-justified').length).to.equal(2)
     expect(_$el.find('.btn-group-justified > .btn-group').length).to.equal(3)

--- a/test/unit/specs/BtnGroup.spec.js
+++ b/test/unit/specs/BtnGroup.spec.js
@@ -7,7 +7,7 @@ describe('BtnGroup', () => {
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(BtnGroup)
+    const Constructor = Vue.extend(BtnGroup)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })

--- a/test/unit/specs/Carousel.spec.js
+++ b/test/unit/specs/Carousel.spec.js
@@ -3,14 +3,14 @@ import $ from 'jquery'
 import Carousel from '@src/components/carousel/Carousel.vue'
 import Slide from '@src/components/carousel/Slide.vue'
 import CarouselDoc from '@docs/pages/components/Carousel.md'
-import utils from './../utils'
+import utils from '../utils'
 
 describe('Carousel', () => {
   let vm
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(CarouselDoc)
+    const Constructor = Vue.extend(CarouselDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -21,14 +21,14 @@ describe('Carousel', () => {
   })
 
   it('should not be able to work if not using <carousel><slide>...</slide></carousel>', () => {
-    let _error = window.console.error
+    const _error = window.console.error
     window.console.error = () => {
       // Silent to remove out logs in terminal
     }
     try {
-      let spy = sinon.spy(window.console, 'error')
-      let res = Vue.compile('<carousel><slide><slide>{{ msg }}</slide></slide></carousel>')
-      let vm = new Vue({
+      const spy = sinon.spy(window.console, 'error')
+      const res = Vue.compile('<carousel><slide><slide>{{ msg }}</slide></slide></carousel>')
+      const _vm = new Vue({
         data () {
           return {
             msg: 'hello'
@@ -39,16 +39,16 @@ describe('Carousel', () => {
         staticRenderFns: res.staticRenderFns
       }).$mount()
       sinon.assert.called(spy)
-      $(vm.$el).remove()
-      vm.$destroy()
+      $(_vm.$el).remove()
+      _vm.$destroy()
     } finally {
       window.console.error = _error
     }
   })
 
   it('should be able to work with v-model', async () => {
-    let res = Vue.compile('<carousel v-model="index"><slide>1</slide><slide>2</slide></carousel>')
-    let vm = new Vue({
+    const res = Vue.compile('<carousel v-model="index"><slide>1</slide><slide>2</slide></carousel>')
+    const _vm = new Vue({
       data () {
         return {
           index: 1
@@ -58,22 +58,22 @@ describe('Carousel', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el)
-    await vm.$nextTick()
+    $el = $(_vm.$el)
+    await _vm.$nextTick()
     expect($el.find('.carousel-inner .item.active').length).to.equal(1)
     expect($el.find('.carousel-inner .item').get(1).className).to.contain('active')
-    $el.find('.carousel-control.right').get(0).click()
+    utils.triggerEvent($el.find('.carousel-control.right').get(0), 'click')
     await utils.sleep(700)
     expect($el.find('.carousel-inner .item.active').length).to.equal(1)
     expect($el.find('.carousel-inner .item').get(0).className).to.contain('active')
-    expect(vm.index).to.equal(0)
+    expect(_vm.index).to.equal(0)
     $el.remove()
-    vm.$destroy()
+    _vm.$destroy()
   })
 
   it('should be ok if no <slide> present in <carousel>', () => {
-    let res = Vue.compile('<carousel>{{msg}}</carousel>')
-    let vm = new Vue({
+    const res = Vue.compile('<carousel>{{msg}}</carousel>')
+    const _vm = new Vue({
       data () {
         return {
           msg: 'hello'
@@ -83,12 +83,12 @@ describe('Carousel', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    $(vm.$el).remove()
-    vm.$destroy()
+    $(_vm.$el).remove()
+    _vm.$destroy()
   })
 
   it('should be able to render correct contents on init', async () => {
-    let $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
+    $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
     await vm.$nextTick()
     expect($el.find('.carousel-inner .item').length).to.equal(4)
     expect($el.find('.carousel-indicators li').length).to.equal(4)
@@ -97,56 +97,57 @@ describe('Carousel', () => {
   })
 
   it('should be able to go next on right control click', async () => {
-    let $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
+    $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
     await vm.$nextTick()
-    $el.find('.carousel-control.right').get(0).click()
+    utils.triggerEvent($el.find('.carousel-control.right').get(0), 'click')
     await utils.sleep(700)
     expect($el.find('.carousel-inner .item.active').length).to.equal(1)
     expect($el.find('.carousel-inner .item').get(1).className).to.contain('active')
   })
 
   it('should be able to go prev on left control click', async () => {
-    let $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
+    $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
     await vm.$nextTick()
-    $el.find('.carousel-control.left').get(0).click()
+    utils.triggerEvent($el.find('.carousel-control.left').get(0), 'click')
     await utils.sleep(700)
     expect($el.find('.carousel-inner .item.active').length).to.equal(1)
     expect($el.find('.carousel-inner .item').get(3).className).to.contain('active')
-    $el.find('.carousel-control.left').get(0).click()
+    utils.triggerEvent($el.find('.carousel-control.left').get(0), 'click')
     await utils.sleep(700)
     expect($el.find('.carousel-inner .item.active').length).to.equal(1)
     expect($el.find('.carousel-inner .item').get(2).className).to.contain('active')
   })
 
   it('should be able to go index on indicator click', async () => {
-    let $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
+    $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
     await vm.$nextTick()
-    $el.find('.carousel-indicators li').get(1).click()
+    const $indicators = $el.find('.carousel-indicators li')
+    utils.triggerEvent($indicators.get(1), 'click')
     await utils.sleep(700)
     expect($el.find('.carousel-indicators .active').length).to.equal(1)
-    expect($el.find('.carousel-indicators li').get(1).className).to.contain('active')
+    expect($indicators.get(1).className).to.contain('active')
     expect($el.find('.carousel-inner .item.active').length).to.equal(1)
     expect($el.find('.carousel-inner .item').get(1).className).to.contain('active')
-    $el.find('.carousel-indicators li').get(0).click()
+    utils.triggerEvent($indicators.get(0), 'click')
     await utils.sleep(700)
     expect($el.find('.carousel-indicators .active').length).to.equal(1)
-    expect($el.find('.carousel-indicators li').get(0).className).to.contain('active')
+    expect($indicators.get(0).className).to.contain('active')
     expect($el.find('.carousel-inner .item.active').length).to.equal(1)
     expect($el.find('.carousel-inner .item').get(0).className).to.contain('active')
   })
 
   it('should be able to hide indicators', async () => {
-    let _$el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
+    const _$el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
     await vm.$nextTick()
-    $el.find('form button').get(0).click()
+    utils.triggerEvent($el.find('form button').get(0), 'click')
     await vm.$nextTick()
     expect(_$el.find('.carousel-indicators').length).to.equal(0)
   })
 
   it('should be able to use custom icons', async () => {
-    let res = Vue.compile('<carousel :icon-control-left="customLeftIcon" icon-control-right="custom-css-class"></carousel>')
-    let leftControlClass = 'my-custom-left-class'
-    let vm = new Vue({
+    const res = Vue.compile('<carousel :icon-control-left="customLeftIcon" icon-control-right="custom-css-class"></carousel>')
+    const leftControlClass = 'my-custom-left-class'
+    const _vm = new Vue({
       data () {
         return {
           customLeftIcon: leftControlClass
@@ -156,32 +157,32 @@ describe('Carousel', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el)
+    $el = $(_vm.$el)
     expect($el.find('.left.carousel-control > span').get(0).className).to.contain(leftControlClass)
     expect($el.find('.right.carousel-control > span').get(0).className).to.contain('custom-css-class')
     $el.remove()
-    vm.$destroy()
+    _vm.$destroy()
   })
 
   it('should be able to hide controls', async () => {
     let _$el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
     await vm.$nextTick()
-    $el.find('form button').get(1).click()
+    utils.triggerEvent($el.find('form button').get(1), 'click')
     await vm.$nextTick()
     expect(_$el.find('.carousel-control').length).to.equal(0)
   })
 
   it('should be able to push slide', async () => {
-    let _$el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
+    const _$el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
     await vm.$nextTick()
-    $el.find('form button').get(2).click()
+    utils.triggerEvent($el.find('form button').get(2), 'click')
     await vm.$nextTick()
     expect(_$el.find('.carousel-indicators li').length).to.equal(5)
     expect(_$el.find('.carousel-inner .item').length).to.equal(5)
   })
 
   it('should be able to change interval', async () => {
-    let $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
+    const $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
     await vm.$nextTick()
     vm.$refs['carousel-example'].interval = 500
     await vm.$nextTick()
@@ -193,7 +194,7 @@ describe('Carousel', () => {
   })
 
   it('should be able to stop interval', async () => {
-    let $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
+    const $el = $(vm.$refs['carousel-example'].$refs.carousel.$el)
     await vm.$nextTick()
     vm.$refs['carousel-example'].interval = 0
     await vm.$nextTick()

--- a/test/unit/specs/Collapse.spec.js
+++ b/test/unit/specs/Collapse.spec.js
@@ -1,14 +1,14 @@
 import Vue from 'vue'
 import $ from 'jquery'
 import CollapseDoc from '@docs/pages/components/Collapse.md'
-import utils from './../utils'
+import utils from '../utils'
 
 describe('Collapse', () => {
   let vm
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(CollapseDoc)
+    const Constructor = Vue.extend(CollapseDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -19,27 +19,27 @@ describe('Collapse', () => {
   })
 
   it('should be able to toggle collapse on trigger click', async () => {
-    let trigger = $el.find(`button`).get(0)
-    let collapse = $el.find(`.collapse`).get(0)
+    const trigger = $el.find('button').get(0)
+    const collapse = $el.find('.collapse').get(0)
     expect(collapse.className).to.equal('collapse')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(400)
     expect(collapse.className).to.equal('collapse in')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(400)
     expect(collapse.className).to.equal('collapse')
   })
 
   it('should be able to toggle accordion', async () => {
-    let triggers = $el.find(`.panel-heading`)
-    let collapse = $el.find(`.collapse`)
+    const triggers = $el.find('.panel-heading')
+    const collapse = $el.find('.collapse')
     expect(collapse.get(1).className).to.equal('collapse in')
     expect(collapse.get(2).className).to.equal('collapse')
-    triggers.get(1).click()
+    utils.triggerEvent(triggers.get(1), 'click')
     await utils.sleep(400)
     expect(collapse.get(1).className).to.equal('collapse')
     expect(collapse.get(2).className).to.equal('collapse in')
-    triggers.get(1).click()
+    utils.triggerEvent(triggers.get(1), 'click')
     await utils.sleep(400)
     expect(collapse.get(2).className).to.equal('collapse')
   })

--- a/test/unit/specs/DatePicker.spec.js
+++ b/test/unit/specs/DatePicker.spec.js
@@ -2,13 +2,14 @@ import Vue from 'vue'
 import DatePicker from '@src/components/datepicker/DatePicker.vue'
 import DatePickerDoc from '@docs/pages/components/DatePicker.md'
 import $ from 'jquery'
+import utils from '../utils'
 
 describe('DatePicker', () => {
   let vm
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(DatePickerDoc)
+    const Constructor = Vue.extend(DatePickerDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -19,8 +20,8 @@ describe('DatePicker', () => {
   })
 
   it('should render correct month and year with given date on init', async () => {
-    let res = Vue.compile('<date-picker v-model="date" ref="datepicker"></date-picker>')
-    let vm = new Vue({
+    const res = Vue.compile('<date-picker v-model="date" ref="datepicker"></date-picker>')
+    const _vm = new Vue({
       data () {
         return {
           date: '1991-08-14'
@@ -30,35 +31,35 @@ describe('DatePicker', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await vm.$nextTick()
-    expect(vm.$refs.datepicker.currentMonth).to.equal(7)
-    expect(vm.$refs.datepicker.currentYear).to.equal(1991)
-    let $el = $(vm.$el)
-    vm.$destroy()
+    await _vm.$nextTick()
+    expect(_vm.$refs.datepicker.currentMonth).to.equal(7)
+    expect(_vm.$refs.datepicker.currentYear).to.equal(1991)
+    $el = $(_vm.$el)
+    _vm.$destroy()
     $el.remove()
   })
 
   it('should be able to render date view', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let dateView = picker.querySelectorAll('table')[0]
+    const dateView = picker.querySelectorAll('table')[0]
     expect(dateView.style.display).to.equal('')
-    let yearMonthBtn = dateView.querySelectorAll('button')[1]
-    let now = new Date()
+    const yearMonthBtn = dateView.querySelectorAll('button')[1]
+    const now = new Date()
     expect(yearMonthBtn.textContent).to.contain(`${now.getFullYear()} ${now.toDateString().split(' ')[1]}`)
-    let todayBtn = dateView.querySelector('.btn-info')
+    const todayBtn = dateView.querySelector('.btn-info')
     expect(todayBtn.textContent).to.equal(now.getDate().toString())
   })
 
   it('should be able to go prev month', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     const goPrev = async (i, actionBtn, now, textBtn) => {
       if (i > 0) {
-        actionBtn.click()
+        utils.triggerEvent(actionBtn, 'click')
         await vm.$nextTick()
         now = new Date(now.getFullYear(), now.getMonth(), 0)
         expect(textBtn.textContent).to.contain(`${now.getFullYear()} ${now.toDateString().split(' ')[1]}`)
@@ -67,9 +68,9 @@ describe('DatePicker', () => {
       }
     }
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let dateView = picker.querySelectorAll('table')[0]
+    const dateView = picker.querySelectorAll('table')[0]
     await goPrev(
       24,
       dateView.querySelectorAll('button')[0],
@@ -78,11 +79,11 @@ describe('DatePicker', () => {
   }).timeout(5000)
 
   it('should be able to go next month', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     const goNext = async (i, actionBtn, now, textBtn) => {
       if (i > 0) {
-        actionBtn.click()
+        utils.triggerEvent(actionBtn, 'click')
         await vm.$nextTick()
         if (now.getMonth() === 11) {
           now = new Date(now.getFullYear() + 1, 0, 1)
@@ -95,9 +96,9 @@ describe('DatePicker', () => {
       }
     }
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let dateView = picker.querySelectorAll('table')[0]
+    const dateView = picker.querySelectorAll('table')[0]
     await goNext(
       24,
       dateView.querySelectorAll('button')[2],
@@ -106,36 +107,36 @@ describe('DatePicker', () => {
   }).timeout(5000)
 
   it('should be able to switch to month view from date view', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
     let picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let dateView = picker.querySelectorAll('table')[0]
-    let yearMonthBtn = dateView.querySelectorAll('button')[1]
-    let monthView = picker.querySelectorAll('table')[1]
+    const dateView = picker.querySelectorAll('table')[0]
+    const yearMonthBtn = dateView.querySelectorAll('button')[1]
+    const monthView = picker.querySelectorAll('table')[1]
     expect(dateView.style.display).to.equal('')
     expect(monthView.style.display).to.equal('none')
-    yearMonthBtn.click()
+    utils.triggerEvent(yearMonthBtn, 'click')
     await vm.$nextTick()
     expect(dateView.style.display).to.equal('none')
     expect(monthView.style.display).to.equal('')
-    let now = new Date()
+    const now = new Date()
     expect(monthView.querySelectorAll('button')[1].textContent).to.equal(now.getFullYear().toString())
   })
 
   it('should be able to switch to date view from month view', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let dateView = picker.querySelectorAll('table')[0]
+    const dateView = picker.querySelectorAll('table')[0]
     let yearMonthBtn = dateView.querySelectorAll('button')[1]
-    let monthView = picker.querySelectorAll('table')[1]
-    yearMonthBtn.click()
+    const monthView = picker.querySelectorAll('table')[1]
+    utils.triggerEvent(yearMonthBtn, 'click')
     await vm.$nextTick()
-    monthView.querySelector('tbody').querySelector('button').click()
+    utils.triggerEvent(monthView.querySelector('tbody').querySelector('button'), 'click')
     await vm.$nextTick()
     expect(dateView.style.display).to.equal('')
     expect(monthView.style.display).to.equal('none')
@@ -146,171 +147,172 @@ describe('DatePicker', () => {
   })
 
   it('should be able to go prev year', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let monthView = picker.querySelectorAll('table')[1]
-    monthView.querySelector('button').click()
+    const monthView = picker.querySelectorAll('table')[1]
+    utils.triggerEvent(monthView.querySelector('button'), 'click')
     await vm.$nextTick()
-    let now = new Date()
+    const now = new Date()
     expect(monthView.querySelectorAll('button')[1].textContent).to.equal(now.getFullYear() - 1 + '')
   })
 
   it('should be able to go next year', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let monthView = picker.querySelectorAll('table')[1]
-    monthView.querySelectorAll('button')[2].click()
+    const monthView = picker.querySelectorAll('table')[1]
+    utils.triggerEvent(monthView.querySelectorAll('button')[2], 'click')
     await vm.$nextTick()
-    let now = new Date()
+    const now = new Date()
     expect(monthView.querySelectorAll('button')[1].textContent).to.equal(now.getFullYear() + 1 + '')
   })
 
   it('should be able to switch to year view from month view', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let yearView = picker.querySelectorAll('table')[2]
-    let monthView = picker.querySelectorAll('table')[1]
-    let yearBtn = monthView.querySelectorAll('button')[1]
+    const yearView = picker.querySelectorAll('table')[2]
+    const monthView = picker.querySelectorAll('table')[1]
+    const yearBtn = monthView.querySelectorAll('button')[1]
     expect(yearView.style.display).to.equal('none')
-    yearBtn.click()
+    utils.triggerEvent(yearBtn, 'click')
     await vm.$nextTick()
     expect(monthView.style.display).to.equal('none')
     expect(yearView.style.display).to.equal('')
-    let now = new Date()
-    let start = now.getFullYear() - now.getFullYear() % 20
-    let yearStr = `${start} ~ ${start + 19}`
+    const now = new Date()
+    const start = now.getFullYear() - now.getFullYear() % 20
+    const yearStr = `${start} ~ ${start + 19}`
     expect(yearView.querySelectorAll('button')[1].textContent).to.equal(yearStr)
   })
 
   it('should be able to switch to month view from year view', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let yearView = picker.querySelectorAll('table')[2]
-    let monthView = picker.querySelectorAll('table')[1]
+    const yearView = picker.querySelectorAll('table')[2]
+    const monthView = picker.querySelectorAll('table')[1]
     expect(monthView.style.display).to.equal('none')
-    yearView.querySelector('tbody').querySelector('button').click()
+    utils.triggerEvent(yearView.querySelector('tbody').querySelector('button'), 'click')
     await vm.$nextTick()
     expect(monthView.style.display).to.equal('')
     expect(yearView.style.display).to.equal('none')
-    let now = new Date()
-    let year = now.getFullYear() - now.getFullYear() % 20
+    const now = new Date()
+    const year = now.getFullYear() - now.getFullYear() % 20
     expect(monthView.querySelectorAll('button')[1].textContent).to.equal(year.toString())
   })
 
   it('should be able to go prev year group', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let yearView = picker.querySelectorAll('table')[2]
-    yearView.querySelector('button').click()
+    const yearView = picker.querySelectorAll('table')[2]
+    utils.triggerEvent(yearView.querySelector('button'), 'click')
     await vm.$nextTick()
-    let now = new Date()
-    let start = now.getFullYear() - now.getFullYear() % 20
-    let yearStr = `${start - 20} ~ ${start - 20 + 19}`
+    const now = new Date()
+    const start = now.getFullYear() - now.getFullYear() % 20
+    const yearStr = `${start - 20} ~ ${start - 20 + 19}`
     expect(yearView.querySelectorAll('button')[1].textContent).to.equal(yearStr)
   })
 
   it('should be able to go next year group', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     expect(picker).to.exist
-    let yearView = picker.querySelectorAll('table')[2]
-    yearView.querySelectorAll('button')[2].click()
+    const yearView = picker.querySelectorAll('table')[2]
+    utils.triggerEvent(yearView.querySelectorAll('button')[2], 'click')
     await vm.$nextTick()
-    let now = new Date()
-    let start = now.getFullYear() - now.getFullYear() % 20
-    let yearStr = `${start + 20} ~ ${start + 20 + 19}`
+    const now = new Date()
+    const start = now.getFullYear() - now.getFullYear() % 20
+    const yearStr = `${start + 20} ~ ${start + 20 + 19}`
     expect(yearView.querySelectorAll('button')[1].textContent).to.equal(yearStr)
   })
 
   it('should be able to select date', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
-    let dateView = picker.querySelectorAll('table')[0]
-    let dateBtn = dateView.querySelector('tbody').querySelectorAll('button')[15]
-    dateBtn.click()
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
+    const dateView = picker.querySelectorAll('table')[0]
+    const dateBtn = dateView.querySelector('tbody').querySelectorAll('button')[15]
+    utils.triggerEvent(dateBtn, 'click')
     await vm.$nextTick()
     expect(dateBtn.className).to.contain('btn-primary')
   })
 
   it('should not close the picker on picker body click', async () => {
-    let _vm = vm.$refs['date-picker-dropdown-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-dropdown-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
-    let dropdown = vm.$el.querySelector('.dropdown')
-    let trigger = dropdown.querySelector('button')
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
+    const dropdown = vm.$el.querySelector('.dropdown')
+    const trigger = dropdown.querySelector('button')
     expect(dropdown.className).not.contain('open')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await vm.$nextTick()
     expect(dropdown.className).to.contain('open')
-    picker.click()
+    utils.triggerEvent(picker, 'click')
     await vm.$nextTick()
     expect(dropdown.className).to.contain('open')
   })
 
   it('should be able to use today btn', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
-    let dateView = picker.querySelectorAll('table')[0]
-    picker.querySelector('.text-center').querySelectorAll('button')[0].click()
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
+    const dateView = picker.querySelectorAll('table')[0]
+    utils.triggerEvent(picker.querySelector('.text-center').querySelectorAll('button')[0], 'click')
     await vm.$nextTick()
     expect(dateView.querySelector('tbody').querySelector('.btn-primary').textContent)
       .to.equal(new Date().getDate().toString())
   })
 
   it('should be able to use clear btn', async () => {
-    let _vm = vm.$refs['date-picker-example']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-example']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
-    let dateView = picker.querySelectorAll('table')[0]
-    picker.querySelector('.text-center').querySelectorAll('button')[0].click()
-    picker.querySelector('.text-center').querySelectorAll('button')[1].click()
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
+    const dateView = picker.querySelectorAll('table')[0]
+    const btns = picker.querySelector('.text-center').querySelectorAll('button')
+    utils.triggerEvent(btns[0], 'click')
+    utils.triggerEvent(btns[1], 'click')
     await vm.$nextTick()
     expect(dateView.querySelector('tbody').querySelectorAll('.btn-primary').length).to.equal(0)
   })
 
   it('should be able to hide today btn', async () => {
-    let _vm = vm.$refs['date-picker-without-buttons']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-without-buttons']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
     expect(_$el.find('button:contains(Today)').length).to.equal(0)
   })
 
   it('should be able to hide clear btn', async () => {
-    let _vm = vm.$refs['date-picker-without-buttons']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-without-buttons']
+    const _$el = $(_vm.$el)
     await vm.$nextTick()
     expect(_$el.find('button:contains(Clear)').length).to.equal(0)
   })
 
   it('should be able to limit date range and render correct date view', async () => {
-    let _vm = vm.$refs['date-picker-range-limit']
-    let _$el = $(_vm.$el)
+    const _vm = vm.$refs['date-picker-range-limit']
+    const _$el = $(_vm.$el)
     _vm.date = '2017-01-01'
     await vm.$nextTick()
-    let picker = _$el.find('[data-role="date-picker"]').get(0)
+    const picker = _$el.find('[data-role="date-picker"]').get(0)
     let btnDisabled = picker.querySelector('tbody').querySelectorAll('button:disabled')
     expect(btnDisabled.length).to.equal(0)
     _vm.date = '2017-12-31'
@@ -320,26 +322,26 @@ describe('DatePicker', () => {
   })
 
   it('should be able to limit date range and not able to set invalid date', async () => {
-    let _vm = vm.$refs['date-picker-range-limit']
+    const _vm = vm.$refs['date-picker-range-limit']
     _vm.date = '2019-01-01'
     await vm.$nextTick()
     expect(_vm.date).to.equal('')
   })
 
   it('should be able to toggle popup picker', async () => {
-    let _vm = vm.$refs['date-picker-dropdown-example']
-    _vm.$el.querySelector('.input-group-btn button').click()
+    const _vm = vm.$refs['date-picker-dropdown-example']
+    utils.triggerEvent(_vm.$el.querySelector('.input-group-btn button'), 'click')
     await vm.$nextTick()
     expect(_vm.$el.querySelector('.dropdown').className).to.contain('open')
-    _vm.$el.querySelector('.input-group-btn button').click()
+    utils.triggerEvent(_vm.$el.querySelector('.input-group-btn button'), 'click')
     await vm.$nextTick()
     expect(_vm.$el.querySelector('.dropdown').className).not.contain('open')
   })
 
   it('should be able to use custom icons', async () => {
-    let _vm = vm.$refs['date-picker-icons-example']
-    let $el = $(_vm.$el)
-    let $tr = $el.find('table:first-child tr:first-child')
+    const _vm = vm.$refs['date-picker-icons-example']
+    const $el = $(_vm.$el)
+    const $tr = $el.find('table:first-child tr:first-child')
     expect($tr.find('td:first-child > .btn > i').get(0).className).to.contain('glyphicon-triangle-left')
     expect($tr.find('td:last-child > .btn > i').get(0).className).to.contain('glyphicon-triangle-right')
   })

--- a/test/unit/specs/Dropdown.spec.js
+++ b/test/unit/specs/Dropdown.spec.js
@@ -2,14 +2,14 @@ import Vue from 'vue'
 import $ from 'jquery'
 import Dropdown from '@src/components/dropdown/Dropdown.vue'
 import DropdownDoc from '@docs/pages/components/Dropdown.md'
-import utils from './../utils'
+import utils from '../utils'
 
 describe('Dropdown', () => {
   let vm
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(DropdownDoc)
+    const Constructor = Vue.extend(DropdownDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -20,9 +20,9 @@ describe('Dropdown', () => {
   })
 
   it('should be able to open dropdown on trigger click', async () => {
-    let _vm = vm.$refs['dropdown-examples']
-    let dropdown = _vm.$el.querySelector(`.dropdown`)
-    let trigger = dropdown.querySelector('button')
+    const _vm = vm.$refs['dropdown-examples']
+    const dropdown = _vm.$el.querySelector('.dropdown')
+    const trigger = dropdown.querySelector('button')
     expect(dropdown.tagName.toLowerCase()).to.equal('div')
     expect(dropdown.className).to.not.contain('open')
     utils.triggerEvent(trigger, 'click')
@@ -31,9 +31,9 @@ describe('Dropdown', () => {
   })
 
   it('should be able to close dropdown on trigger click', async () => {
-    let _vm = vm.$refs['dropdown-examples']
-    let dropdown = _vm.$el.querySelector(`.dropdown`)
-    let trigger = dropdown.querySelector('button')
+    const _vm = vm.$refs['dropdown-examples']
+    const dropdown = _vm.$el.querySelector('.dropdown')
+    const trigger = dropdown.querySelector('button')
     expect(dropdown.tagName.toLowerCase()).to.equal('div')
     expect(dropdown.className).to.not.contain('open')
     utils.triggerEvent(trigger, 'click')
@@ -45,9 +45,9 @@ describe('Dropdown', () => {
   })
 
   it('should be able to close dropdown on window click', async () => {
-    let _vm = vm.$refs['dropdown-examples']
-    let dropdown = _vm.$el.querySelector(`.dropdown`)
-    let trigger = dropdown.querySelector('button')
+    const _vm = vm.$refs['dropdown-examples']
+    const dropdown = _vm.$el.querySelector('.dropdown')
+    const trigger = dropdown.querySelector('button')
     expect(dropdown.tagName.toLowerCase()).to.equal('div')
     expect(dropdown.className).to.not.contain('open')
     utils.triggerEvent(trigger, 'click')
@@ -60,9 +60,9 @@ describe('Dropdown', () => {
   })
 
   it('should be able to open dropdown append to body on trigger click', async () => {
-    let _vm = vm.$refs['dropdown-append-to-body']
-    let dropdown = _vm.$el.querySelector(`.dropdown`)
-    let trigger = dropdown.querySelector('button')
+    const _vm = vm.$refs['dropdown-append-to-body']
+    const dropdown = _vm.$el.querySelector('.dropdown')
+    const trigger = dropdown.querySelector('button')
     expect(dropdown.className).to.not.contain('open')
     expect(dropdown.querySelector('.dropdown-menu')).to.exist
     utils.triggerEvent(trigger, 'click')
@@ -76,24 +76,24 @@ describe('Dropdown', () => {
   })
 
   it('should be able to use dropup style', async () => {
-    let _vm = vm.$refs['dropdown-dropup']
+    const _vm = vm.$refs['dropdown-dropup']
     await vm.$nextTick()
-    let dropup = _vm.$el.querySelector(`.dropup`)
+    const dropup = _vm.$el.querySelector('.dropup')
     expect(dropup.className).to.not.contain('open')
     expect(dropup.querySelector('.dropdown-menu')).to.exist
   })
 
   it('should be able to use menu-right style', async () => {
-    let _vm = vm.$refs['dropdown-menu-right']
+    const _vm = vm.$refs['dropdown-menu-right']
     await vm.$nextTick()
-    let menuRight = _vm.$el.querySelector(`.dropdown`)
+    const menuRight = _vm.$el.querySelector('.dropdown')
     expect(menuRight.querySelector('.dropdown-menu').className).to.contain('dropdown-menu-right')
   })
 
   it('should be able to open dropdown append to body & menu-right on trigger click', async () => {
-    let _vm = vm.$refs['dropdown-append-to-body']
-    let dropdown = _vm.$el.querySelectorAll(`.dropdown`)[1]
-    let trigger = dropdown.querySelector('button')
+    const _vm = vm.$refs['dropdown-append-to-body']
+    const dropdown = _vm.$el.querySelectorAll(`.dropdown`)[1]
+    const trigger = dropdown.querySelector('button')
     expect(dropdown.className).to.not.contain('open')
     expect(dropdown.querySelector('.dropdown-menu-right')).to.exist
     utils.triggerEvent(trigger, 'click')
@@ -107,9 +107,9 @@ describe('Dropdown', () => {
   })
 
   it('should be able to open dropdown append to body & dropup on trigger click', async () => {
-    let _vm = vm.$refs['dropdown-append-to-body']
-    let dropdown = _vm.$el.querySelector(`.dropup`)
-    let trigger = dropdown.querySelector('button')
+    const _vm = vm.$refs['dropdown-append-to-body']
+    const dropdown = _vm.$el.querySelector('.dropup')
+    const trigger = dropdown.querySelector('button')
     expect(dropdown.className).to.not.contain('open')
     expect(dropdown.querySelector('.dropdown-menu')).to.exist
     utils.triggerEvent(trigger, 'click')
@@ -123,8 +123,8 @@ describe('Dropdown', () => {
   })
 
   it('should be able to open dropdown on init', async () => {
-    let res = Vue.compile('<dropdown v-model="show"><button class="btn btn-default dropdown-toggle" type="button"><span>Dropdown 1</span><span class="caret"></span></button><template slot="dropdown"><li><a href="#">Action</a></li></template></dropdown>')
-    let vm = new Vue({
+    const res = Vue.compile('<dropdown v-model="show"><button class="btn btn-default dropdown-toggle" type="button"><span>Dropdown 1</span><span class="caret"></span></button><template slot="dropdown"><li><a href="#">Action</a></li></template></dropdown>')
+    const vm = new Vue({
       data () {
         return {
           show: true
@@ -135,9 +135,9 @@ describe('Dropdown', () => {
       staticRenderFns: res.staticRenderFns
     }).$mount()
     await vm.$nextTick()
-    let dropdown = vm.$el
+    const dropdown = vm.$el
     expect(dropdown.className).to.contain('open')
-    let $el = $(vm.$el)
+    $el = $(vm.$el)
     vm.$destroy()
     $el.remove()
   })

--- a/test/unit/specs/Modal.spec.js
+++ b/test/unit/specs/Modal.spec.js
@@ -9,7 +9,7 @@ describe('Modal', () => {
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(ModalDoc)
+    const Constructor = Vue.extend(ModalDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -20,11 +20,11 @@ describe('Modal', () => {
   })
 
   it('should be able to open modal 1', async () => {
-    let _vm = vm.$refs['modal-example']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
+    const _vm = vm.$refs['modal-example']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(_$el.find('.modal').get(0).className).to.contain('in')
@@ -32,11 +32,11 @@ describe('Modal', () => {
   })
 
   it('should be able to close by esc key click', async () => {
-    let _vm = vm.$refs['modal-example']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
+    const _vm = vm.$refs['modal-example']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(_$el.find('.modal').get(0).className).to.contain('in')
@@ -50,16 +50,16 @@ describe('Modal', () => {
   })
 
   it('should be able to close modal 1 and fire callback', async () => {
-    let _vm = vm.$refs['modal-example']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
+    const _vm = vm.$refs['modal-example']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(_$el.find('.modal').get(0).className).to.contain('in')
     expect(_$el.find('.modal-title').get(0).textContent).to.equal('Modal 1')
-    _$el.find('button.close').get(0).click()
+    utils.triggerEvent(_$el.find('button.close').get(0), 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).not.exist
     expect(_$el.find('.modal').get(0).className).not.contain('in')
@@ -67,16 +67,16 @@ describe('Modal', () => {
   })
 
   it('should be able to close modal 1 with ok option and fire callback', async () => {
-    let _vm = vm.$refs['modal-example']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
+    const _vm = vm.$refs['modal-example']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(_$el.find('.modal').get(0).className).to.contain('in')
     expect(_$el.find('.modal-title').get(0).textContent).to.equal('Modal 1')
-    _$el.find('.modal-footer button').get(1).click()
+    utils.triggerEvent(_$el.find('.modal-footer button').get(1), 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).not.exist
     expect(_$el.find('.modal').get(0).className).not.contain('in')
@@ -84,12 +84,12 @@ describe('Modal', () => {
   })
 
   it('should be able to render large modal', async () => {
-    let _vm = vm.$refs['modal-optional-sizes']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
-    let modal = vm.$el.querySelectorAll('.modal')[1]
+    const _vm = vm.$refs['modal-optional-sizes']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
+    const modal = vm.$el.querySelectorAll('.modal')[1]
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
@@ -97,12 +97,12 @@ describe('Modal', () => {
   })
 
   it('should be able to render small modal', async () => {
-    let _vm = vm.$refs['modal-optional-sizes']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(1)
-    let modal = vm.$el.querySelectorAll('.modal')[2]
+    const _vm = vm.$refs['modal-optional-sizes']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(1)
+    const modal = vm.$el.querySelectorAll('.modal')[2]
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
@@ -110,12 +110,12 @@ describe('Modal', () => {
   })
 
   it('should be able to render HTML title modal', async () => {
-    let _vm = vm.$refs['modal-custom-header']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
-    let modal = vm.$el.querySelectorAll('.modal')[3]
+    const _vm = vm.$refs['modal-custom-header']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
+    const modal = vm.$el.querySelectorAll('.modal')[3]
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
@@ -123,12 +123,12 @@ describe('Modal', () => {
   })
 
   it('should be able to render no header modal', async () => {
-    let _vm = vm.$refs['modal-custom-header']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(1)
-    let modal = vm.$el.querySelectorAll('.modal')[4]
+    const _vm = vm.$refs['modal-custom-header']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(1)
+    const modal = vm.$el.querySelectorAll('.modal')[4]
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
@@ -136,12 +136,12 @@ describe('Modal', () => {
   })
 
   it('should be able to render customize footer modal', async () => {
-    let _vm = vm.$refs['modal-custom-footer']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
-    let modal = vm.$el.querySelectorAll('.modal')[5]
+    const _vm = vm.$refs['modal-custom-footer']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
+    const modal = vm.$el.querySelectorAll('.modal')[5]
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
@@ -149,12 +149,12 @@ describe('Modal', () => {
   })
 
   it('should be able to render no footer modal', async () => {
-    let _vm = vm.$refs['modal-custom-footer']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(1)
-    let modal = vm.$el.querySelectorAll('.modal')[6]
+    const _vm = vm.$refs['modal-custom-footer']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(1)
+    const modal = vm.$el.querySelectorAll('.modal')[6]
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
@@ -162,68 +162,68 @@ describe('Modal', () => {
   })
 
   it('should be able to close customize footer modal', async () => {
-    let _vm = vm.$refs['modal-custom-footer']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
-    let modal = vm.$el.querySelectorAll('.modal')[5]
+    const _vm = vm.$refs['modal-custom-footer']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
+    const modal = vm.$el.querySelectorAll('.modal')[5]
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
     expect(modal.querySelectorAll('.modal-footer button').length).to.equal(3)
-    modal.querySelectorAll('.modal-footer button')[0].click()
+    utils.triggerEvent(modal.querySelectorAll('.modal-footer button')[0], 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).not.exist
     expect(modal.className).not.contain('in')
   })
 
   it('should be able to auto-focus on ok btn', async () => {
-    let _vm = vm.$refs['modal-auto-focus']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
+    const _vm = vm.$refs['modal-auto-focus']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration + 100)
     // expect(vm.$refs.modal9.$el.querySelector('[data-action="auto-focus"]')).to.equal(vm.$refs.modal9.$el.querySelector(':focus'))
     // have no idea how to get this focused element
   })
 
   it('should be able to close modal on backdrop click', async () => {
-    let _vm = vm.$refs['modal-example']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
-    let modal = vm.$el.querySelectorAll('.modal')[0]
+    const _vm = vm.$refs['modal-example']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
+    const modal = vm.$el.querySelectorAll('.modal')[0]
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
-    modal.click()
+    utils.triggerEvent(modal, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).not.exist
     expect(modal.className).not.contain('in')
   })
 
   it('should not be able to close backdrop-false modal', async () => {
-    let _vm = vm.$refs['modal-disable-backdrop']
-    let _$el = $(_vm.$el)
-    let trigger = _$el.find('.btn').get(0)
-    let modal = vm.$el.querySelectorAll('.modal')[8]
+    const _vm = vm.$refs['modal-disable-backdrop']
+    const _$el = $(_vm.$el)
+    const trigger = _$el.find('.btn').get(0)
+    const modal = vm.$el.querySelectorAll('.modal')[8]
     expect(document.querySelector('.modal-backdrop')).not.exist
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
-    modal.click()
+    utils.triggerEvent(modal, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
   })
 
   it('should be able to open modal on init', async () => {
-    let res = Vue.compile('<modal v-model="open" title="Modal 1"><p>This is a simple modal.</p></modal>')
-    let vm = new Vue({
+    const res = Vue.compile('<modal v-model="open" title="Modal 1"><p>This is a simple modal.</p></modal>')
+    const vm = new Vue({
       data () {
         return {
           open: true

--- a/test/unit/specs/Pagination.spec.js
+++ b/test/unit/specs/Pagination.spec.js
@@ -1,13 +1,14 @@
 import Vue from 'vue'
 import $ from 'jquery'
 import PaginationDoc from '@docs/pages/components/Pagination.md'
+import utils from '../utils'
 
 describe('Pagination', () => {
   let vm
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(PaginationDoc)
+    const Constructor = Vue.extend(PaginationDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -18,48 +19,48 @@ describe('Pagination', () => {
   })
 
   it('should be able to hide boundary links', async () => {
-    let _vm = vm.$refs['pagination-example']
+    const _vm = vm.$refs['pagination-example']
     await vm.$nextTick()
-    let pagination = _vm.$el.querySelector('.pagination')
-    let first = pagination.querySelector('[aria-label="First"]')
-    let last = pagination.querySelector('[aria-label="Last"]')
+    const pagination = _vm.$el.querySelector('.pagination')
+    const first = pagination.querySelector('[aria-label="First"]')
+    const last = pagination.querySelector('[aria-label="Last"]')
     expect(first).to.not.exist
     expect(last).to.not.exist
   })
 
   it('should be able to show boundary links', async () => {
-    let _vm = vm.$refs['pagination-boundary-links']
-    let pagination = _vm.$el.querySelector('.pagination')
-    let first = pagination.querySelector('[aria-label="First"]')
-    let last = pagination.querySelector('[aria-label="Last"]')
+    const _vm = vm.$refs['pagination-boundary-links']
+    const pagination = _vm.$el.querySelector('.pagination')
+    const first = pagination.querySelector('[aria-label="First"]')
+    const last = pagination.querySelector('[aria-label="Last"]')
     expect(first).to.exist
     expect(last).to.exist
   })
 
   it('should be able to hide direction links', async () => {
-    let _vm = vm.$refs['pagination-direction-links']
+    const _vm = vm.$refs['pagination-direction-links']
     _vm.directionLinks = true
     await vm.$nextTick()
-    let pagination = _vm.$el.querySelectorAll('ul.pagination')[1]
-    let pre = pagination.querySelector('[aria-label="Previous"]')
-    let next = pagination.querySelector('[aria-label="Next"]')
+    const pagination = _vm.$el.querySelectorAll('ul.pagination')[1]
+    const pre = pagination.querySelector('[aria-label="Previous"]')
+    const next = pagination.querySelector('[aria-label="Next"]')
     expect(pre).to.not.exist
     expect(next).to.not.exist
   })
 
   it('should be able to show direction links', async () => {
-    let _vm = vm.$refs['pagination-direction-links']
+    const _vm = vm.$refs['pagination-direction-links']
     _vm.directionLinks = true
     await vm.$nextTick()
-    let pagination = _vm.$el.querySelectorAll('ul.pagination')[0]
-    let pre = pagination.querySelector('[aria-label="Previous"]')
-    let next = pagination.querySelector('[aria-label="Next"]')
+    const pagination = _vm.$el.querySelectorAll('ul.pagination')[0]
+    const pre = pagination.querySelector('[aria-label="Previous"]')
+    const next = pagination.querySelector('[aria-label="Next"]')
     expect(pre).to.exist
     expect(next).to.exist
   })
 
   it('should be able to change current page', async () => {
-    let _vm = vm.$refs['pagination-example']
+    const _vm = vm.$refs['pagination-example']
     _vm.currentPage = 1
     await vm.$nextTick()
     let pagination = _vm.$el.querySelector('ul.pagination')
@@ -73,7 +74,7 @@ describe('Pagination', () => {
   })
 
   it('should be able to change size', async () => {
-    let _vm = vm.$refs['pagination-sizing']
+    const _vm = vm.$refs['pagination-sizing']
     await vm.$nextTick()
     expect(_vm.$el.querySelectorAll('.pagination')[0].className).to.equal('pagination pagination-lg')
     expect(_vm.$el.querySelectorAll('.pagination')[1].className).to.equal('pagination')
@@ -81,36 +82,36 @@ describe('Pagination', () => {
   })
 
   it('should be able to change total page', async () => {
-    let _vm = vm.$refs['pagination-boundary-links']
+    const _vm = vm.$refs['pagination-boundary-links']
     _vm.totalPage = 18
     await vm.$nextTick()
-    let pagination = _vm.$el.querySelector('ul.pagination')
-    let lastBtn = pagination.querySelector('[aria-label="Last"]')
-    lastBtn.click()
+    const pagination = _vm.$el.querySelector('ul.pagination')
+    const lastBtn = pagination.querySelector('[aria-label="Last"]')
+    utils.triggerEvent(lastBtn, 'click')
     await vm.$nextTick()
     let activeBtn = pagination.querySelector('.active a')
     expect(Number(activeBtn.text)).to.equal(_vm.totalPage)
     _vm.totalPage = 100
     await vm.$nextTick()
-    lastBtn.click()
+    utils.triggerEvent(lastBtn, 'click')
     await vm.$nextTick()
     activeBtn = pagination.querySelector('.active a')
     expect(Number(activeBtn.text)).to.equal(_vm.totalPage)
   })
 
   it('should be able to go to first page', async () => {
-    let _vm = vm.$refs['pagination-boundary-links']
+    const _vm = vm.$refs['pagination-boundary-links']
     _vm.totalPage = 18
     _vm.currentPage = 18
     await vm.$nextTick()
-    let pagination = _vm.$el.querySelector('ul.pagination')
-    let lastBtn = pagination.querySelector('[aria-label="Last"]')
-    lastBtn.click()
+    const pagination = _vm.$el.querySelector('ul.pagination')
+    const lastBtn = pagination.querySelector('[aria-label="Last"]')
+    utils.triggerEvent(lastBtn, 'click')
     await vm.$nextTick()
     let activeBtn = pagination.querySelector('.active a')
     expect(Number(activeBtn.text)).to.equal(_vm.totalPage)
-    let firstBtn = pagination.querySelector('[aria-label="First"]')
-    firstBtn.click()
+    const firstBtn = pagination.querySelector('[aria-label="First"]')
+    utils.triggerEvent(firstBtn, 'click')
     await vm.$nextTick()
     activeBtn = pagination.querySelector('.active a')
     expect(_vm.currentPage).to.equal(1)
@@ -118,7 +119,7 @@ describe('Pagination', () => {
   })
 
   it('last group has max size item', async () => {
-    let _vm = vm.$refs['pagination-example']
+    const _vm = vm.$refs['pagination-example']
     _vm.currentPage = 18
     await vm.$nextTick()
     let pagination = _vm.$el.querySelector('ul.pagination')
@@ -132,19 +133,19 @@ describe('Pagination', () => {
   })
 
   it('should be go to next group', async () => {
-    let _vm = vm.$refs['pagination-example']
+    const _vm = vm.$refs['pagination-example']
     _vm.totalPage = 13
     await vm.$nextTick()
     let pagination = _vm.$el.querySelector('ul.pagination')
-    let nextGroupBtn = pagination.querySelector('[aria-label="Next group"]')
+    const nextGroupBtn = pagination.querySelector('[aria-label="Next group"]')
     let startBtn = $(pagination).find('a:not([aria-label])').get(0)
     expect(Number(startBtn.text)).to.equal(1)
-    nextGroupBtn.click()
+    utils.triggerEvent(nextGroupBtn, 'click')
     await vm.$nextTick()
     pagination = _vm.$el.querySelector('ul.pagination')
     startBtn = $(pagination).find('a:not([aria-label])').get(0)
     expect(Number(startBtn.text)).to.equal(1 + 5)
-    nextGroupBtn.click()
+    utils.triggerEvent(nextGroupBtn, 'click')
     await vm.$nextTick()
     pagination = _vm.$el.querySelector('ul.pagination')
     startBtn = $(pagination).find('a:not([aria-label])').get(0)
@@ -152,20 +153,20 @@ describe('Pagination', () => {
   })
 
   it('should be go to perv group', async () => {
-    let _vm = vm.$refs['pagination-example']
+    const _vm = vm.$refs['pagination-example']
     _vm.totalPage = 13
     _vm.currentPage = 12
     await vm.$nextTick()
     let pagination = _vm.$el.querySelector('ul.pagination')
-    let prevGroupBtn = pagination.querySelector('[aria-label="Previous group"]')
+    const prevGroupBtn = pagination.querySelector('[aria-label="Previous group"]')
     let startBtn = $(pagination).find('a:not([aria-label])').get(0)
     expect(Number(startBtn.text)).to.equal(_vm.totalPage - 5 + 1)
-    prevGroupBtn.click()
+    utils.triggerEvent(prevGroupBtn, 'click')
     await vm.$nextTick()
     pagination = _vm.$el.querySelector('ul.pagination')
     startBtn = $(pagination).find('a:not([aria-label])').get(0)
     expect(Number(startBtn.text)).to.equal(_vm.totalPage - 5 * 2 + 1)
-    prevGroupBtn.click()
+    utils.triggerEvent(prevGroupBtn, 'click')
     await vm.$nextTick()
     pagination = _vm.$el.querySelector('ul.pagination')
     startBtn = $(pagination).find('a:not([aria-label])').get(0)

--- a/test/unit/specs/Popover.spec.js
+++ b/test/unit/specs/Popover.spec.js
@@ -2,14 +2,14 @@ import Vue from 'vue'
 import $ from 'jquery'
 import Popover from '@src/components/popover/Popover.vue'
 import PopoverDoc from '@docs/pages/components/Popover.md'
-import utils from './../utils'
+import utils from '../utils'
 
 describe('Popover', () => {
   let vm
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(PopoverDoc)
+    const Constructor = Vue.extend(PopoverDoc)
     vm = new Constructor().$mount()
     $('body').css('text-align', 'center').css('padding-top', '200px')
     $el = $(vm.$el).appendTo('body')
@@ -31,8 +31,8 @@ describe('Popover', () => {
   })
 
   it('should be able to show popover on init', async () => {
-    let res = Vue.compile('<popover v-model="show" title="123"><button data-role="trigger"></button></popover>')
-    let vm = new Vue({
+    const res = Vue.compile('<popover v-model="show" title="123"><button data-role="trigger"></button></popover>')
+    const _vm = new Vue({
       data () {
         return {
           show: true
@@ -44,14 +44,14 @@ describe('Popover', () => {
     }).$mount()
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
-    $(vm.$el).remove()
+    $(_vm.$el).remove()
     $('.popover').remove()
-    vm.$destroy()
+    _vm.$destroy()
   })
 
   it('should be able to use popover directive', async () => {
-    let res = Vue.compile('<btn v-popover="msg"></btn>')
-    let vm = new Vue({
+    const res = Vue.compile('<btn v-popover="msg"></btn>')
+    const _vm = new Vue({
       data () {
         return {
           msg: {title: 'title', content: 'content'}
@@ -60,45 +60,45 @@ describe('Popover', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await vm.$nextTick()
-    let trigger = vm.$el
-    trigger.click()
+    await _vm.$nextTick()
+    const trigger = _vm.$el
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     let popover = document.querySelector('.popover')
     expect(popover).to.exist
     expect(popover.querySelector('.popover-title').innerText).to.equal('title')
     expect(popover.querySelector('.popover-content').innerText).to.equal('content')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
     // this should work
-    vm.msg = {title: 'title2', content: 'content2'}
-    await vm.$nextTick()
-    trigger.click()
+    _vm.msg = {title: 'title2', content: 'content2'}
+    await _vm.$nextTick()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     popover = document.querySelector('.popover')
     expect(popover).to.exist
     expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
     expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
     // this should not work
-    vm.$set(vm.msg, 'title', 'title3')
-    await vm.$nextTick()
-    trigger.click()
+    _vm.$set(_vm.msg, 'title', 'title3')
+    await _vm.$nextTick()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     popover = document.querySelector('.popover')
     expect(popover).to.exist
     expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
     expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
-    vm.$destroy()
+    _vm.$destroy()
   })
 
   it('directive with invalid modifiers should be ok', async () => {
     // invalid modifier should be ok
-    let res = Vue.compile('<btn v-popover.test1.test2="msg"></btn>')
-    let vm = new Vue({
+    const res = Vue.compile('<btn v-popover.test1.test2="msg"></btn>')
+    const _vm = new Vue({
       data () {
         return {
           msg: {title: 'title', content: 'content'}
@@ -107,23 +107,23 @@ describe('Popover', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await vm.$nextTick()
-    let trigger = vm.$el
-    trigger.click()
+    await _vm.$nextTick()
+    const trigger = _vm.$el
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
-    let popover = document.querySelector('.popover')
+    const popover = document.querySelector('.popover')
     expect(popover).to.exist
     expect(popover.querySelector('.popover-title').innerText).to.equal('title')
     expect(popover.querySelector('.popover-content').innerText).to.equal('content')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    vm.$destroy()
+    _vm.$destroy()
   })
 
   it('should not show popover with no title and content', async () => {
-    let res = Vue.compile('<popover v-model="show"><button data-role="trigger"></button></popover>')
-    let vm = new Vue({
+    const res = Vue.compile('<popover v-model="show"><button data-role="trigger"></button></popover>')
+    const _vm = new Vue({
       data () {
         return {
           show: true
@@ -135,14 +135,14 @@ describe('Popover', () => {
     }).$mount()
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    $(vm.$el).remove()
+    $(_vm.$el).remove()
     $('.popover').remove()
-    vm.$destroy()
+    _vm.$destroy()
   })
 
   it('should be able to use custom target', async () => {
-    let res = Vue.compile('<div><button ref="btn" type="button">btn</button><popover :target="btn" trigger="focus" title="123"></popover></div>')
-    let vm = new Vue({
+    const res = Vue.compile('<div><button ref="btn" type="button">btn</button><popover :target="btn" trigger="focus" title="123"></popover></div>')
+    const _vm = new Vue({
       data () {
         return {
           btn: null
@@ -155,31 +155,31 @@ describe('Popover', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el).appendTo('body')
-    await vm.$nextTick()
+    const $el = $(_vm.$el).appendTo('body')
+    await _vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    vm.btn.focus()
+    utils.triggerEvent(_vm.btn, 'focus')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
     $el.remove()
     $('.popover').remove()
-    vm.$destroy()
+    _vm.$destroy()
   })
 
   it('should be able to show popover on click', async () => {
-    let _vm = vm.$refs['popover-example']
+    const _vm = vm.$refs['popover-example']
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    _vm.$el.querySelector('button').click()
+    utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
-    _vm.$el.querySelector('button').click()
+    utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to change trigger to manual', async () => {
-    let _vm = vm.$refs['popover-manual-trigger']
+    const _vm = vm.$refs['popover-manual-trigger']
     expect(document.querySelectorAll('.popover').length).to.equal(0)
     _vm.show = true
     await utils.sleep(200)
@@ -190,40 +190,40 @@ describe('Popover', () => {
   })
 
   it('should be able change trigger to hover-focus', async () => {
-    let _vm = vm.$refs['popover-triggers']
+    const _vm = vm.$refs['popover-triggers']
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
     // matches don't work in here
-    let savedMatches = Element.prototype.matches
+    const savedMatches = Element.prototype.matches
     Element.prototype.matches = () => true
-    let trigger = _vm.$el.querySelectorAll('button')[3]
-    trigger.focus()
+    const trigger = _vm.$el.querySelectorAll('button')[3]
+    utils.triggerEvent(trigger, 'focus')
     await utils.sleep(200)
     Element.prototype.matches = savedMatches
     expect(document.querySelectorAll('.popover').length).to.equal(1)
-    trigger.blur()
+    utils.triggerEvent(trigger, 'blur')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to change trigger to click', async () => {
-    let _vm = vm.$refs['popover-triggers']
+    const _vm = vm.$refs['popover-triggers']
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[4]
-    trigger.click()
+    const trigger = _vm.$el.querySelectorAll('button')[4]
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to change trigger to hover', async () => {
-    let _vm = vm.$refs['popover-triggers']
+    const _vm = vm.$refs['popover-triggers']
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[1]
+    const trigger = _vm.$el.querySelectorAll('button')[1]
     utils.triggerEvent(trigger, 'mouseenter')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
@@ -237,121 +237,121 @@ describe('Popover', () => {
   })
 
   it('should be able to toggle correctly on fast click', async () => {
-    let _vm = vm.$refs['popover-triggers']
-    let button = _vm.$el.querySelectorAll('button')[4]
+    const _vm = vm.$refs['popover-triggers']
+    const button = _vm.$el.querySelectorAll('button')[4]
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    button.click()
-    button.click()
-    button.click()
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
-    button.click()
-    button.click()
-    button.click()
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to change trigger to outside-click', async () => {
-    let _vm = vm.$refs['popover-triggers']
-    let button = _vm.$el.querySelectorAll('button')[0]
+    const _vm = vm.$refs['popover-triggers']
+    const button = _vm.$el.querySelectorAll('button')[0]
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    button.click()
+    utils.triggerEvent(button, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
-    document.body.click()
+    document.body.click() // utils.triggerEvent() doesn't work here...
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to disable', async () => {
-    let _vm = vm.$refs['popover-disable']
+    const _vm = vm.$refs['popover-disable']
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    _vm.$el.querySelector('button').click()
+    utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to hide title', async () => {
-    let _vm = vm.$refs['popover-with-empty-title']
+    const _vm = vm.$refs['popover-with-empty-title']
     await vm.$nextTick()
-    let trigger = _vm.$el.querySelector('button')
+    const trigger = _vm.$el.querySelector('button')
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
     expect(document.querySelector('.popover .popover-title').style.display).to.equal('none')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to change placement to top', async () => {
-    let _vm = vm.$refs['popover-placements']
+    const _vm = vm.$refs['popover-placements']
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[1]
-    trigger.click()
+    const trigger = _vm.$el.querySelectorAll('button')[1]
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
-    let popover = document.querySelector('.popover')
+    const popover = document.querySelector('.popover')
     expect(popover).to.exist
     expect(popover.className).to.contain('top')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to change placement to bottom', async () => {
-    let _vm = vm.$refs['popover-placements']
+    const _vm = vm.$refs['popover-placements']
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[2]
-    trigger.click()
+    const trigger = _vm.$el.querySelectorAll('button')[2]
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
-    let popover = document.querySelector('.popover')
+    const popover = document.querySelector('.popover')
     expect(popover).to.exist
     expect(popover.className).to.contain('bottom')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to change placement to left', async () => {
-    let _vm = vm.$refs['popover-placements']
+    const _vm = vm.$refs['popover-placements']
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[0]
-    trigger.click()
+    const trigger = _vm.$el.querySelectorAll('button')[0]
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
-    let popover = document.querySelector('.popover')
+    const popover = document.querySelector('.popover')
     expect(popover).to.exist
     expect(popover.className).to.contain('left')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to change placement to right', async () => {
-    let _vm = vm.$refs['popover-placements']
+    const _vm = vm.$refs['popover-placements']
     await vm.$nextTick()
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[3]
-    trigger.click()
+    const trigger = _vm.$el.querySelectorAll('button')[3]
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
-    let popover = document.querySelector('.popover')
+    const popover = document.querySelector('.popover')
     expect(popover).to.exist
     expect(popover.className).to.contain('right')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
   })
 
   it('should be able to change trigger in runtime', async () => {
-    let res = Vue.compile('<popover title="123" :trigger="trigger"><button data-role="trigger"></button></popover>')
-    let vm = new Vue({
+    const res = Vue.compile('<popover title="123" :trigger="trigger"><button data-role="trigger"></button></popover>')
+    const _vm = new Vue({
       data () {
         return {
           trigger: 'focus'
@@ -361,22 +361,22 @@ describe('Popover', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el).appendTo('body')
+    const $el = $(_vm.$el).appendTo('body')
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-    await vm.$nextTick()
-    let trigger = vm.$el.querySelector('button')
-    trigger.focus()
+    await _vm.$nextTick()
+    const trigger = _vm.$el.querySelector('button')
+    utils.triggerEvent(trigger, 'focus')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
-    vm.trigger = 'click'
-    await vm.$nextTick()
-    trigger.blur()
+    _vm.trigger = 'click'
+    await _vm.$nextTick()
+    utils.triggerEvent(trigger, 'blur')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
     $el.remove()
-    vm.$destroy()
+    _vm.$destroy()
   })
 })

--- a/test/unit/specs/ProgressBar.spec.js
+++ b/test/unit/specs/ProgressBar.spec.js
@@ -7,7 +7,7 @@ describe('ProgressBar', () => {
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(ProgressBarDoc)
+    const Constructor = Vue.extend(ProgressBarDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -19,49 +19,49 @@ describe('ProgressBar', () => {
 
   it('should be able to render default', async () => {
     await vm.$nextTick()
-    let bars = vm.$el.querySelectorAll('.progress')
+    const bars = vm.$el.querySelectorAll('.progress')
     expect(bars[0].querySelector('.progress-bar').style.width).to.equal('66%')
   })
 
   it('should be able to render label', async () => {
     await vm.$nextTick()
-    let bars = vm.$el.querySelectorAll('.progress')
+    const bars = vm.$el.querySelectorAll('.progress')
     expect(bars[1].querySelector('.progress-bar').textContent).to.equal('66%')
   })
 
   it('should be able to render custom label', async () => {
     await vm.$nextTick()
-    let bars = vm.$el.querySelectorAll('.progress')
+    const bars = vm.$el.querySelectorAll('.progress')
     expect(bars[2].querySelector('.progress-bar').textContent).to.contain('Loading...')
   })
 
   it('should be able to render label with min width', async () => {
     await vm.$nextTick()
-    let bars = vm.$el.querySelectorAll('.progress')
+    const bars = vm.$el.querySelectorAll('.progress')
     expect(bars[3].querySelector('.progress-bar').style.minWidth).to.equal('2em')
   })
 
   it('should be able to render different types', async () => {
     await vm.$nextTick()
-    let bars = vm.$el.querySelectorAll('.progress')
+    const bars = vm.$el.querySelectorAll('.progress')
     expect(bars[4].querySelector('.progress-bar').className).to.contain('progress-bar-success')
   })
 
   it('should be able to render striped', async () => {
     await vm.$nextTick()
-    let bars = vm.$el.querySelectorAll('.progress')
+    const bars = vm.$el.querySelectorAll('.progress')
     expect(bars[8].querySelector('.progress-bar').className).to.contain('progress-bar-striped')
   })
 
   it('should be able to render animation', async () => {
     await vm.$nextTick()
-    let bars = vm.$el.querySelectorAll('.progress')
+    const bars = vm.$el.querySelectorAll('.progress')
     expect(bars[12].querySelector('.progress-bar').className).to.contain('active')
   })
 
   it('should be able to render stacked', async () => {
     await vm.$nextTick()
-    let bars = vm.$el.querySelectorAll('.progress')
+    const bars = vm.$el.querySelectorAll('.progress')
     expect(bars[13].querySelectorAll('.progress-bar').length).to.equal(3)
   })
 })

--- a/test/unit/specs/Tabs.spec.js
+++ b/test/unit/specs/Tabs.spec.js
@@ -10,7 +10,7 @@ describe('Tabs', () => {
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(TabsDoc)
+    const Constructor = Vue.extend(TabsDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el)
   })
@@ -21,14 +21,14 @@ describe('Tabs', () => {
   })
 
   it('should not be able to work if not using <tabs><tab>...</tab></tabs>', () => {
-    let _error = window.console.error
+    const _error = window.console.error
     window.console.error = () => {
       // Silent to remove out logs in terminal
     }
     try {
-      let spy = sinon.spy(window.console, 'error')
-      let res = Vue.compile('<tabs><tab><tab>{{ msg }}</tab></tab></tabs>')
-      let vm = new Vue({
+      const spy = sinon.spy(window.console, 'error')
+      const res = Vue.compile('<tabs><tab><tab>{{ msg }}</tab></tab></tabs>')
+      const vm = new Vue({
         data () {
           return {
             msg: 'hello'
@@ -48,8 +48,8 @@ describe('Tabs', () => {
   })
 
   it('should be ok if no <tab> present in <tabs>', () => {
-    let res = Vue.compile('<tabs>{{msg}}</tabs>')
-    let vm = new Vue({
+    const res = Vue.compile('<tabs>{{msg}}</tabs>')
+    const vm = new Vue({
       data () {
         return {
           msg: 'hello'
@@ -67,21 +67,21 @@ describe('Tabs', () => {
   it('should be able to render first tab on open', async () => {
     await vm.$nextTick()
     await vm.$nextTick()
-    let nav = $el.find('.nav-tabs').get(0)
-    let content = $el.find('.tab-content').get(0)
-    let activeTab = nav.querySelectorAll('.active')
+    const nav = $el.find('.nav-tabs').get(0)
+    const content = $el.find('.tab-content').get(0)
+    const activeTab = nav.querySelectorAll('.active')
     expect(activeTab.length).to.equal(1)
     expect(activeTab[0].querySelector('a').textContent).to.equal('Home')
-    let activeContent = content.querySelectorAll('.tab-pane.active')
+    const activeContent = content.querySelectorAll('.tab-pane.active')
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].querySelector('p').textContent).to.contain('Raw denim you probably haven')
   })
 
   it('should be able to open correct tab content after click on tab nav', async () => {
     await vm.$nextTick()
-    let nav = $el.find('.nav-tabs').get(0)
-    let content = $el.find('.tab-content').get(0)
-    let tab = nav.querySelectorAll('li')[1].querySelector('a')
+    const nav = $el.find('.nav-tabs').get(0)
+    const content = $el.find('.tab-content').get(0)
+    const tab = nav.querySelectorAll('li')[1].querySelector('a')
     utils.triggerEvent(tab, 'click')
     await vm.$nextTick()
     await utils.sleep(350)
@@ -89,20 +89,20 @@ describe('Tabs', () => {
     utils.triggerEvent(tab, 'click')
     await vm.$nextTick()
     await utils.sleep(350)
-    let activeTab = nav.querySelectorAll('.active')
+    const activeTab = nav.querySelectorAll('.active')
     expect(activeTab.length).to.equal(1)
     expect(activeTab[0].querySelector('a').textContent).to.equal('Profile')
-    let activeContent = content.querySelectorAll('.tab-pane.active')
+    const activeContent = content.querySelectorAll('.tab-pane.active')
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].querySelector('p').textContent).to.contain('Food truck fixie locavore, accusamus mcsw')
   })
 
   it('should not be able to select disabled tab', async () => {
     await vm.$nextTick()
-    let nav = $el.find('.nav-tabs').get(1)
-    let content = $el.find('.tab-content').get(1)
+    const nav = $el.find('.nav-tabs').get(1)
+    const content = $el.find('.tab-content').get(1)
     // In nav
-    let tab1 = nav.querySelectorAll('li')[1]
+    const tab1 = nav.querySelectorAll('li')[1]
     expect(tab1.className).to.equal('disabled')
     utils.triggerEvent(tab1.querySelector('a'), 'click')
     await vm.$nextTick()
@@ -112,7 +112,7 @@ describe('Tabs', () => {
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].querySelector('p').textContent).to.contain('Home tab')
     // In dropdown
-    let tab2 = nav.querySelector('.dropdown').querySelectorAll('li')[1]
+    const tab2 = nav.querySelector('.dropdown').querySelectorAll('li')[1]
     expect(tab2.className).to.equal('disabled')
     utils.triggerEvent(tab2.querySelector('a'), 'click')
     await vm.$nextTick()
@@ -125,19 +125,19 @@ describe('Tabs', () => {
 
   it('should be able to render HTML title', async () => {
     await vm.$nextTick()
-    let nav = $el.find('.nav-tabs').get(4)
-    let tab = nav.querySelectorAll('li')[2]
+    const nav = $el.find('.nav-tabs').get(4)
+    const tab = nav.querySelectorAll('li')[2]
     expect(tab.querySelector('i')).to.exist
   })
 
   it('should be able to run callback function', async () => {
     await vm.$nextTick()
-    let nav = $el.find('.nav-tabs').get(4)
-    let _savedAlert = window.alert
+    const nav = $el.find('.nav-tabs').get(4)
+    const _savedAlert = window.alert
     window.alert = () => {
       // Silent to remove out logs in terminal
     }
-    let spy = sinon.spy(window, 'alert')
+    const spy = sinon.spy(window, 'alert')
     utils.triggerEvent(nav.querySelectorAll('li > a')[1], 'click')
     await vm.$nextTick()
     await utils.sleep(350)
@@ -150,9 +150,9 @@ describe('Tabs', () => {
 
   it('should be able to open grouped tab', async () => {
     await vm.$nextTick()
-    let nav = $el.find('.nav-tabs').get(0)
-    let content = $el.find('.tab-content').get(0)
-    let tab5 = nav.querySelector('li.dropdown')
+    const nav = $el.find('.nav-tabs').get(0)
+    const content = $el.find('.tab-content').get(0)
+    const tab5 = nav.querySelector('li.dropdown')
     utils.triggerEvent(tab5.querySelectorAll('a')[0], 'click')
     await vm.$nextTick()
     await utils.sleep(350)
@@ -163,95 +163,95 @@ describe('Tabs', () => {
     await vm.$nextTick()
     await utils.sleep(350)
     expect(tab5.className).to.contain('active')
-    let activeContent = content.querySelectorAll('.tab-pane.active')
+    const activeContent = content.querySelectorAll('.tab-pane.active')
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].querySelector('p').textContent).to.contain('Etsy mixtape wayfarers')
   })
 
   it('should be able to use with v-model', async () => {
-    let _vm = vm.$refs['tabs-dynamic-example']
-    let $el = $(_vm.$el)
+    const _vm = vm.$refs['tabs-dynamic-example']
+    const $el = $(_vm.$el)
     await vm.$nextTick()
     await vm.$nextTick()
-    let nav = $el.find('.nav-tabs').get(0)
-    let content = $el.find('.tab-content').get(0)
+    const nav = $el.find('.nav-tabs').get(0)
+    const content = $el.find('.tab-content').get(0)
     expect(nav.querySelectorAll('li').length).to.equal(1)
     // check active tab
-    let activeTab = nav.querySelectorAll('.active')
+    const activeTab = nav.querySelectorAll('.active')
     expect(activeTab.length).to.equal(1)
     expect(activeTab[0].querySelector('a').textContent).to.equal('Tab 0')
     // check active content
-    let activeContent = content.querySelectorAll('.tab-pane.active')
+    const activeContent = content.querySelectorAll('.tab-pane.active')
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].textContent).to.contain('Tab 0')
   })
 
   it('should be able to push tab', async () => {
-    let _vm = vm.$refs['tabs-dynamic-example']
-    let $el = $(_vm.$el)
-    let nav = $el.find('.nav-tabs').get(0)
-    let content = $el.find('.tab-content').get(0)
-    let pushBtn = $el.find('.btn').get(0)
+    const _vm = vm.$refs['tabs-dynamic-example']
+    const $el = $(_vm.$el)
+    const nav = $el.find('.nav-tabs').get(0)
+    const content = $el.find('.tab-content').get(0)
+    const pushBtn = $el.find('.btn').get(0)
     await vm.$nextTick()
     await vm.$nextTick()
     // Add a tab
-    pushBtn.click()
+    utils.triggerEvent(pushBtn, 'click')
     await vm.$nextTick()
     await utils.sleep(350)
     expect(nav.querySelectorAll('li').length).to.equal(2)
     // check active tab
-    let activeTab = nav.querySelectorAll('.active')
+    const activeTab = nav.querySelectorAll('.active')
     expect(activeTab.length).to.equal(1)
     expect(activeTab[0].querySelector('a').textContent).to.equal('Tab 1')
     // check active content
-    let activeContent = content.querySelectorAll('.tab-pane.active')
+    const activeContent = content.querySelectorAll('.tab-pane.active')
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].textContent).to.contain('Tab 1')
   })
 
   it('should be able to pop tab', async () => {
-    let _vm = vm.$refs['tabs-dynamic-example']
-    let $el = $(_vm.$el)
-    let nav = $el.find('.nav-tabs').get(0)
-    let content = $el.find('.tab-content').get(0)
-    let pushBtn = $el.find('.btn').get(0)
-    let popBtn = $el.find('.btn').get(1)
+    const _vm = vm.$refs['tabs-dynamic-example']
+    const $el = $(_vm.$el)
+    const nav = $el.find('.nav-tabs').get(0)
+    const content = $el.find('.tab-content').get(0)
+    const pushBtn = $el.find('.btn').get(0)
+    const popBtn = $el.find('.btn').get(1)
     await vm.$nextTick()
     await vm.$nextTick()
     // Add a tab
-    pushBtn.click()
+    utils.triggerEvent(pushBtn, 'click')
     await vm.$nextTick()
     await utils.sleep(350)
     // Delete a tab
-    popBtn.click()
+    utils.triggerEvent(popBtn, 'click')
     await vm.$nextTick()
     await utils.sleep(350)
     expect(nav.querySelectorAll('li').length).to.equal(1)
     // check active tab
-    let activeTab = nav.querySelectorAll('.active')
+    const activeTab = nav.querySelectorAll('.active')
     expect(activeTab.length).to.equal(1)
     expect(activeTab[0].querySelector('a').textContent).to.equal('Tab 0')
     // check active content
-    let activeContent = content.querySelectorAll('.tab-pane.active')
+    const activeContent = content.querySelectorAll('.tab-pane.active')
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].textContent).to.contain('Tab 0')
   })
 
   it('should be able to select dynamic tab', async () => {
-    let _vm = vm.$refs['tabs-dynamic-example']
-    let $el = $(_vm.$el)
-    let nav = $el.find('.nav-tabs').get(0)
-    let content = $el.find('.tab-content').get(0)
-    let pushBtn = $el.find('.btn').get(0)
-    let popBtn = $el.find('.btn').get(1)
+    const _vm = vm.$refs['tabs-dynamic-example']
+    const $el = $(_vm.$el)
+    const nav = $el.find('.nav-tabs').get(0)
+    const content = $el.find('.tab-content').get(0)
+    const pushBtn = $el.find('.btn').get(0)
+    const popBtn = $el.find('.btn').get(1)
     await vm.$nextTick()
     await vm.$nextTick()
     // Add a tab
-    pushBtn.click()
+    utils.triggerEvent(pushBtn, 'click')
     await vm.$nextTick()
-    pushBtn.click()
+    utils.triggerEvent(pushBtn, 'click')
     await vm.$nextTick()
-    pushBtn.click()
+    utils.triggerEvent(pushBtn, 'click')
     await vm.$nextTick()
     await utils.sleep(350)
     expect(nav.querySelectorAll('li').length).to.equal(4)
@@ -266,7 +266,7 @@ describe('Tabs', () => {
     let activeContent = content.querySelectorAll('.tab-pane.active')
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].textContent).to.contain('Tab 1')
-    popBtn.click()
+    utils.triggerEvent(popBtn, 'click')
     await vm.$nextTick()
     await utils.sleep(350)
     expect(nav.querySelectorAll('li').length).to.equal(3)
@@ -279,7 +279,7 @@ describe('Tabs', () => {
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].textContent).to.contain('Tab 1')
     // switch tab
-    let tab2 = nav.querySelectorAll('li')[2]
+    const tab2 = nav.querySelectorAll('li')[2]
     utils.triggerEvent(tab2.querySelector('a'), 'click')
     await vm.$nextTick()
     await utils.sleep(350)

--- a/test/unit/specs/TimePicker.spec.js
+++ b/test/unit/specs/TimePicker.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import $ from 'jquery'
-import utils from './../utils'
+import utils from '../utils'
 import TimePickerDoc from '@docs/pages/components/TimePicker.md'
 
 describe('TimePicker', () => {

--- a/test/unit/specs/Tooltip.spec.js
+++ b/test/unit/specs/Tooltip.spec.js
@@ -2,14 +2,14 @@ import Vue from 'vue'
 import $ from 'jquery'
 import Tooltip from '@src/components/tooltip/Tooltip.vue'
 import TooltipDoc from '@docs/pages/components/Tooltip.md'
-import utils from './../utils'
+import utils from '../utils'
 
 describe('Tooltip', () => {
   let vm
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(TooltipDoc)
+    const Constructor = Vue.extend(TooltipDoc)
     vm = new Constructor().$mount()
     $('body').css('text-align', 'center').css('padding-top', '200px')
     $el = $(vm.$el).appendTo('body')
@@ -23,11 +23,11 @@ describe('Tooltip', () => {
   })
 
   it('should be able to append to custom tags', async () => {
-    let tag = document.createElement('div')
+    const tag = document.createElement('div')
     tag.id = 'tag'
     document.body.appendChild(tag)
-    let res = Vue.compile('<tooltip trigger="focus" text="test" append-to="#tag"><button type="button">{{msg}}</button></tooltip>')
-    let vm = new Vue({
+    const res = Vue.compile('<tooltip trigger="focus" text="test" append-to="#tag"><button type="button">{{msg}}</button></tooltip>')
+    const vm = new Vue({
       data () {
         return {
           msg: 'hello'
@@ -37,10 +37,10 @@ describe('Tooltip', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el)
+    const $el = $(vm.$el)
     $el.appendTo('body')
     await vm.$nextTick()
-    vm.$el.querySelector('button').focus()
+    utils.triggerEvent(vm.$el.querySelector('button'), 'focus')
     await utils.sleep(200)
     expect(tag.querySelector('.tooltip')).to.exist
     $el.remove()
@@ -49,8 +49,8 @@ describe('Tooltip', () => {
   })
 
   it('should be able to render with no content', async () => {
-    let res = Vue.compile('<tooltip text="test"></tooltip>')
-    let vm = new Vue({
+    const res = Vue.compile('<tooltip text="test"></tooltip>')
+    const vm = new Vue({
       data () {
         return {
           msg: 'hello'
@@ -60,7 +60,7 @@ describe('Tooltip', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el)
+    const $el = $(vm.$el)
     $el.appendTo('body')
     await vm.$nextTick()
     $el.remove()
@@ -68,8 +68,8 @@ describe('Tooltip', () => {
   })
 
   it('should be able to show tooltip on init', async () => {
-    let res = Vue.compile('<tooltip text="test" v-model="show"><button></button></tooltip>')
-    let vm = new Vue({
+    const res = Vue.compile('<tooltip text="test" v-model="show"><button></button></tooltip>')
+    const vm = new Vue({
       data () {
         return {
           show: true
@@ -79,7 +79,7 @@ describe('Tooltip', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el)
+    const $el = $(vm.$el)
     $el.appendTo('body')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
@@ -88,8 +88,8 @@ describe('Tooltip', () => {
   })
 
   it('should not show tooltip with empty text', async () => {
-    let res = Vue.compile('<tooltip v-model="show"><button></button></tooltip>')
-    let vm = new Vue({
+    const res = Vue.compile('<tooltip v-model="show"><button></button></tooltip>')
+    const vm = new Vue({
       data () {
         return {
           show: true
@@ -99,7 +99,7 @@ describe('Tooltip', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el)
+    const $el = $(vm.$el)
     $el.appendTo('body')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
@@ -108,8 +108,8 @@ describe('Tooltip', () => {
   })
 
   it('should be able to use custom target', async () => {
-    let res = Vue.compile('<div><button ref="btn" type="button">btn</button><tooltip text="test" :target="btn" trigger="focus"></tooltip></div>')
-    let vm = new Vue({
+    const res = Vue.compile('<div><button ref="btn" type="button">btn</button><tooltip text="test" :target="btn" trigger="focus"></tooltip></div>')
+    const vm = new Vue({
       data () {
         return {
           btn: null
@@ -122,11 +122,11 @@ describe('Tooltip', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el)
+    const $el = $(vm.$el)
     $el.appendTo('body')
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    vm.btn.focus()
+    utils.triggerEvent(vm.btn, 'focus')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
     $el.remove()
@@ -134,8 +134,8 @@ describe('Tooltip', () => {
   })
 
   it('should be able to use tooltip directive', async () => {
-    let res = Vue.compile('<btn v-tooltip.click="msg">{{test}}</btn>')
-    let vm = new Vue({
+    const res = Vue.compile('<btn v-tooltip.click="msg">{{test}}</btn>')
+    const vm = new Vue({
       data () {
         return {
           msg: 'title',
@@ -146,30 +146,30 @@ describe('Tooltip', () => {
       staticRenderFns: res.staticRenderFns
     }).$mount()
     await vm.$nextTick()
-    let trigger = vm.$el
-    trigger.click()
+    const trigger = vm.$el
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     let tooltip = document.querySelector('.tooltip')
     expect(tooltip).to.exist
     expect(tooltip.querySelector('.tooltip-inner').innerText).to.equal('title')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
     // this should work
     vm.msg = 'title2'
     await vm.$nextTick()
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     tooltip = document.querySelector('.tooltip')
     expect(tooltip).to.exist
     expect(tooltip.querySelector('.tooltip-inner').innerText).to.equal('title2')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
     // this should not work
     vm.test = 'test2'
     await vm.$nextTick()
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     tooltip = document.querySelector('.tooltip')
     expect(tooltip).to.exist
@@ -179,8 +179,8 @@ describe('Tooltip', () => {
 
   it('directive with invalid modifiers should be ok', async () => {
     // invalid modifier should be ok
-    let res = Vue.compile('<btn v-tooltip.test1.test2.click="msg"></btn>')
-    let vm = new Vue({
+    const res = Vue.compile('<btn v-tooltip.test1.test2.click="msg"></btn>')
+    const vm = new Vue({
       data () {
         return {
           msg: 'title'
@@ -190,37 +190,37 @@ describe('Tooltip', () => {
       staticRenderFns: res.staticRenderFns
     }).$mount()
     await vm.$nextTick()
-    let trigger = vm.$el
-    trigger.click()
+    const trigger = vm.$el
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
-    let tooltip = document.querySelector('.tooltip')
+    const tooltip = document.querySelector('.tooltip')
     expect(tooltip).to.exist
     expect(tooltip.querySelector('.tooltip-inner').innerText).to.equal('title')
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
     vm.$destroy()
   })
 
   it('should be able to show tooltip', async () => {
-    let _vm = vm.$refs['tooltip-example']
+    const _vm = vm.$refs['tooltip-example']
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    let trigger = _vm.$el.querySelector('button')
+    const trigger = _vm.$el.querySelector('button')
     // matches don't work in here
-    let savedMatches = Element.prototype.matches
+    const savedMatches = Element.prototype.matches
     Element.prototype.matches = () => true
-    trigger.focus()
+    utils.triggerEvent(trigger, 'focus')
     await utils.sleep(200)
     Element.prototype.matches = savedMatches
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
-    trigger.blur()
+    utils.triggerEvent(trigger, 'blur')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
   })
 
   it('should be able to change trigger to manual', async () => {
-    let _vm = vm.$refs['tooltip-manual-trigger']
+    const _vm = vm.$refs['tooltip-manual-trigger']
     _vm.show = true
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
@@ -230,10 +230,10 @@ describe('Tooltip', () => {
   })
 
   it('should be able to keep tooltip show on hover if using hover trigger', async () => {
-    let _vm = vm.$refs['tooltip-triggers']
+    const _vm = vm.$refs['tooltip-triggers']
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[1]
+    const trigger = _vm.$el.querySelectorAll('button')[1]
     utils.triggerEvent(trigger, 'mouseenter')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
@@ -247,134 +247,134 @@ describe('Tooltip', () => {
   })
 
   it('should be able to toggle correctly on fast click', async () => {
-    let _vm = vm.$refs['tooltip-triggers']
-    let button = _vm.$el.querySelectorAll('button')[3]
+    const _vm = vm.$refs['tooltip-triggers']
+    const button = _vm.$el.querySelectorAll('button')[3]
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    button.click()
-    button.click()
-    button.click()
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
-    button.click()
-    button.click()
-    button.click()
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
   })
 
   it('should be able to change trigger to click', async () => {
-    let _vm = vm.$refs['tooltip-triggers']
+    const _vm = vm.$refs['tooltip-triggers']
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    _vm.$el.querySelectorAll('button')[3].click()
+    utils.triggerEvent(_vm.$el.querySelectorAll('button')[3], 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
-    _vm.$el.querySelectorAll('button')[3].click()
+    utils.triggerEvent(_vm.$el.querySelectorAll('button')[3], 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
   })
 
   it('should be able to change trigger to outside-click', async () => {
-    let _vm = vm.$refs['tooltip-triggers']
-    let button = _vm.$el.querySelectorAll('button')[4]
+    const _vm = vm.$refs['tooltip-triggers']
+    const button = _vm.$el.querySelectorAll('button')[4]
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    button.click()
+    utils.triggerEvent(button, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
-    document.body.click()
+    document.body.click() // utils.triggerEvent() doesn't work here...
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
   })
 
   it('should be able to disable', async () => {
-    let _vm = vm.$refs['tooltip-disable']
+    const _vm = vm.$refs['tooltip-disable']
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    let savedMatches = Element.prototype.matches
+    const savedMatches = Element.prototype.matches
     Element.prototype.matches = () => true
-    _vm.$el.querySelector('button').focus()
+    utils.triggerEvent(_vm.$el.querySelector('button'), 'focus')
     await utils.sleep(200)
     Element.prototype.matches = savedMatches
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
   })
 
   it('should be able to change placement to top', async () => {
-    let _vm = vm.$refs['tooltip-placements']
+    const _vm = vm.$refs['tooltip-placements']
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[1]
-    let savedMatches = Element.prototype.matches
+    const trigger = _vm.$el.querySelectorAll('button')[1]
+    const savedMatches = Element.prototype.matches
     Element.prototype.matches = () => true
-    trigger.focus()
+    utils.triggerEvent(trigger, 'focus')
     await utils.sleep(200)
     Element.prototype.matches = savedMatches
-    let tooltip = document.querySelector('.tooltip')
+    const tooltip = document.querySelector('.tooltip')
     expect(tooltip).to.exist
     expect(tooltip.className).to.contain('top')
-    trigger.blur()
+    utils.triggerEvent(trigger, 'blur')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
   })
 
   it('should be able to change placement to bottom', async () => {
-    let _vm = vm.$refs['tooltip-placements']
+    const _vm = vm.$refs['tooltip-placements']
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[2]
-    let savedMatches = Element.prototype.matches
+    const trigger = _vm.$el.querySelectorAll('button')[2]
+    const savedMatches = Element.prototype.matches
     Element.prototype.matches = () => true
-    trigger.focus()
+    utils.triggerEvent(trigger, 'focus')
     await utils.sleep(200)
     Element.prototype.matches = savedMatches
-    let tooltip = document.querySelector('.tooltip')
+    const tooltip = document.querySelector('.tooltip')
     expect(tooltip).to.exist
     expect(tooltip.className).to.contain('bottom')
-    trigger.blur()
+    utils.triggerEvent(trigger, 'blur')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
   })
 
   it('should be able to change placement to left', async () => {
-    let _vm = vm.$refs['tooltip-placements']
+    const _vm = vm.$refs['tooltip-placements']
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[0]
-    let savedMatches = Element.prototype.matches
+    const trigger = _vm.$el.querySelectorAll('button')[0]
+    const savedMatches = Element.prototype.matches
     Element.prototype.matches = () => true
-    trigger.focus()
+    utils.triggerEvent(trigger, 'focus')
     await utils.sleep(200)
     Element.prototype.matches = savedMatches
-    let tooltip = document.querySelector('.tooltip')
+    const tooltip = document.querySelector('.tooltip')
     expect(tooltip).to.exist
     expect(tooltip.className).to.contain('left')
-    trigger.blur()
+    utils.triggerEvent(trigger, 'blur')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
   })
 
   it('should be able to change placement to right', async () => {
-    let _vm = vm.$refs['tooltip-placements']
+    const _vm = vm.$refs['tooltip-placements']
     await vm.$nextTick()
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
-    let trigger = _vm.$el.querySelectorAll('button')[3]
-    let savedMatches = Element.prototype.matches
+    const trigger = _vm.$el.querySelectorAll('button')[3]
+    const savedMatches = Element.prototype.matches
     Element.prototype.matches = () => true
-    trigger.focus()
+    utils.triggerEvent(trigger, 'focus')
     await utils.sleep(200)
     Element.prototype.matches = savedMatches
-    let tooltip = document.querySelector('.tooltip')
+    const tooltip = document.querySelector('.tooltip')
     expect(tooltip).to.exist
     expect(tooltip.className).to.contain('right')
-    trigger.blur()
+    utils.triggerEvent(trigger, 'blur')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
   })
 
   it('should be able to change trigger in runtime', async () => {
-    let res = Vue.compile('<tooltip text="test" :trigger="trigger"><button></button></tooltip>')
-    let vm = new Vue({
+    const res = Vue.compile('<tooltip text="test" :trigger="trigger"><button></button></tooltip>')
+    const vm = new Vue({
       data () {
         return {
           trigger: 'focus'
@@ -384,19 +384,19 @@ describe('Tooltip', () => {
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    let $el = $(vm.$el).appendTo('body')
+    const $el = $(vm.$el).appendTo('body')
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
     await vm.$nextTick()
-    let trigger = vm.$el.querySelector('button')
-    trigger.focus()
+    const trigger = vm.$el.querySelector('button')
+    utils.triggerEvent(trigger, 'focus')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
     vm.trigger = 'click'
     await vm.$nextTick()
-    trigger.blur()
+    utils.triggerEvent(trigger, 'blur')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(1)
-    trigger.click()
+    utils.triggerEvent(trigger, 'click')
     await utils.sleep(200)
     expect(document.querySelectorAll('.tooltip').length).to.equal(0)
     $el.remove()

--- a/test/unit/specs/Typeahead.spec.js
+++ b/test/unit/specs/Typeahead.spec.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import $ from 'jquery'
 // import Typeahead from '@src/components/typeahead/Typeahead.vue'
 import TypeaheadDoc from '@docs/pages/components/Typeahead.md'
-import utils from './../utils'
+import utils from '../utils'
 
 describe('Typeahead', () => {
   let xhr, requests, server
@@ -10,7 +10,7 @@ describe('Typeahead', () => {
   let $el
 
   beforeEach(() => {
-    let Constructor = Vue.extend(TypeaheadDoc)
+    const Constructor = Vue.extend(TypeaheadDoc)
     vm = new Constructor().$mount()
     $el = $(vm.$el).appendTo('body')
   })
@@ -35,40 +35,40 @@ describe('Typeahead', () => {
   })
 
   it('should be able to open typeahead when input change', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
     await vm.$nextTick()
     expect(dropdown.className).to.contain('open')
     expect(dropdown.querySelectorAll('li').length).to.equal(3)
-    let selected = dropdown.querySelector('li.active a')
+    const selected = dropdown.querySelector('li.active a')
     expect(selected.textContent).to.equal('Alabama')
   })
 
   it('should be able to open typeahead on input focus', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'focus')
     await vm.$nextTick()
     expect(dropdown.className).to.contain('open')
     expect(dropdown.querySelectorAll('li').length).to.equal(3)
-    let selected = dropdown.querySelector('li.active a')
+    const selected = dropdown.querySelector('li.active a')
     expect(selected.textContent).to.equal('Alabama')
   })
 
   it('should be able to close typeahead on input blur', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
@@ -80,10 +80,10 @@ describe('Typeahead', () => {
   })
 
   it('should not close typeahead on input click', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
@@ -95,10 +95,10 @@ describe('Typeahead', () => {
   })
 
   it('should be able to close typeahead when input changed to empty', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
@@ -111,25 +111,25 @@ describe('Typeahead', () => {
   })
 
   it('should be able to slice item length', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'a'
     utils.triggerEvent(input, 'input')
     await vm.$nextTick()
     expect(dropdown.className).to.contain('open')
     expect(dropdown.querySelectorAll('li').length).to.equal(10)
-    let selected = dropdown.querySelector('li.active a')
+    const selected = dropdown.querySelector('li.active a')
     expect(selected.textContent).to.equal('Alabama')
   })
 
   it('should not open dropdown if nothing match', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'asdasdasdasd'
     utils.triggerEvent(input, 'input')
@@ -138,19 +138,19 @@ describe('Typeahead', () => {
   })
 
   it('should be able to select item', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
     await vm.$nextTick()
     expect(dropdown.className).to.contain('open')
     expect(dropdown.querySelectorAll('li').length).to.equal(3)
-    let selected = dropdown.querySelector('li.active a')
+    const selected = dropdown.querySelector('li.active a')
     expect(selected.textContent).to.equal('Alabama')
-    selected.click()
+    utils.triggerEvent(selected, 'click')
     await vm.$nextTick()
     expect(dropdown.className).to.not.contain('open')
     expect(input.value).to.equal('Alabama')
@@ -158,11 +158,11 @@ describe('Typeahead', () => {
   })
 
   it('should be able to use force select', async () => {
-    let _vm = vm.$refs['typeahead-force-select']
+    const _vm = vm.$refs['typeahead-force-select']
     _vm.forceSelect = true
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
@@ -170,9 +170,9 @@ describe('Typeahead', () => {
     expect(_vm.model).not.exist
     expect(dropdown.className).to.contain('open')
     expect(dropdown.querySelectorAll('li').length).to.equal(3)
-    let selected = dropdown.querySelector('li.active a')
+    const selected = dropdown.querySelector('li.active a')
     expect(selected.textContent).to.equal('Alabama')
-    selected.click()
+    utils.triggerEvent(selected, 'click')
     await vm.$nextTick()
     expect(dropdown.className).to.not.contain('open')
     expect(input.value).to.equal('Alabama')
@@ -180,10 +180,10 @@ describe('Typeahead', () => {
   })
 
   it('should not be able to select item using keyboard while dropdown not open', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     utils.triggerKey(input, utils.keyCodes.enter, 'down')
     await vm.$nextTick()
@@ -192,17 +192,17 @@ describe('Typeahead', () => {
   })
 
   it('should be able to select item using keyboard', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
     await vm.$nextTick()
     expect(dropdown.className).to.contain('open')
     expect(dropdown.querySelectorAll('li').length).to.equal(3)
-    let selected = dropdown.querySelector('li.active a')
+    const selected = dropdown.querySelector('li.active a')
     expect(selected.textContent).to.equal('Alabama')
     utils.triggerKey(input, 13)
     await vm.$nextTick()
@@ -212,10 +212,10 @@ describe('Typeahead', () => {
   })
 
   it('should be able use keyboard nav to go next', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
@@ -237,10 +237,10 @@ describe('Typeahead', () => {
   })
 
   it('should be able use keyboard nav to go prev', async () => {
-    let _vm = vm.$refs['typeahead-example']
+    const _vm = vm.$refs['typeahead-example']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
@@ -270,11 +270,11 @@ describe('Typeahead', () => {
   })
 
   it('should be able to match start', async () => {
-    let _vm = vm.$refs['typeahead-match-start']
+    const _vm = vm.$refs['typeahead-match-start']
     _vm.matchStart = true
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     input.value = 'ala'
     utils.triggerEvent(input, 'input')
@@ -284,13 +284,13 @@ describe('Typeahead', () => {
   })
 
   it('should be able to use async typeahead', async () => {
-    let _vm = vm.$refs['typeahead-async-query']
+    const _vm = vm.$refs['typeahead-async-query']
     await vm.$nextTick()
-    let input = _vm.$el.querySelector('input')
-    let dropdown = _vm.$el.querySelector('.dropdown')
+    const input = _vm.$el.querySelector('input')
+    const dropdown = _vm.$el.querySelector('.dropdown')
     expect(dropdown.className).to.not.contain('open')
     // matches don't work in here
-    let savedMatches = Element.prototype.matches
+    const savedMatches = Element.prototype.matches
     Element.prototype.matches = () => true
     input.value = 'wxsm'
     utils.triggerEvent(input, 'input')
@@ -303,7 +303,7 @@ describe('Typeahead', () => {
     await vm.$nextTick()
     expect(dropdown.className).to.contain('open')
     expect(dropdown.querySelectorAll('li').length).to.equal(1)
-    let selected = dropdown.querySelector('li.active a span')
+    const selected = dropdown.querySelector('li.active a span')
     expect(selected.textContent).to.equal('wxsms')
     Element.prototype.matches = savedMatches
   })

--- a/test/unit/specs/arrayUtils.spec.js
+++ b/test/unit/specs/arrayUtils.spec.js
@@ -3,13 +3,13 @@ import * as utils from '@src/utils/arrayUtils'
 describe('arrayUtils', () => {
   describe('#spliceIfExist', () => {
     it('should be able to handle non array object', () => {
-      let test = null
+      const test = null
       utils.spliceIfExist(test, undefined)
       expect(test).to.be.null
     })
 
     it('should be able to handle non in array object', () => {
-      let arr = [0, 1, 2]
+      const arr = [0, 1, 2]
       utils.spliceIfExist(arr, 3)
       expect(arr.length).to.equal(3)
       expect(arr[0]).to.equal(0)
@@ -18,7 +18,7 @@ describe('arrayUtils', () => {
     })
 
     it('should be able to splice if exist', () => {
-      let arr = [0, 1, 2]
+      const arr = [0, 1, 2]
       utils.spliceIfExist(arr, 1)
       expect(arr.length).to.equal(2)
       expect(arr[0]).to.equal(0)

--- a/test/unit/specs/domUtils.spec.js
+++ b/test/unit/specs/domUtils.spec.js
@@ -24,7 +24,7 @@ describe('domUtils', () => {
   })
 
   it('should be able to use `toggleBodyOverflow` with `enable = false`', () => {
-    let $body = $('html, body')
+    const $body = $('html, body')
     $body.css('height', '9999px')
     utils.toggleBodyOverflow(false)
     expect(document.body.style.paddingRight).to.contain(`px`)
@@ -33,12 +33,12 @@ describe('domUtils', () => {
   })
 
   it('should be able to use `getScrollbarWidth` with `recalculate = false`', () => {
-    let width = utils.getScrollbarWidth(false)
+    const width = utils.getScrollbarWidth(false)
     expect(width).to.above(0)
   })
 
   it('should be able to use `getScrollbarWidth` with `recalculate = true`', () => {
-    let width = utils.getScrollbarWidth(true)
+    const width = utils.getScrollbarWidth(true)
     expect(width).to.above(0)
   })
 })

--- a/test/unit/specs/httpUtils.spec.js
+++ b/test/unit/specs/httpUtils.spec.js
@@ -18,8 +18,8 @@ describe('httpUtils', () => {
   })
 
   it('should be able to get with success callback', () => {
-    let then = sinon.spy()
-    let always = sinon.spy()
+    const then = sinon.spy()
+    const always = sinon.spy()
     utils.getRequest('/some/path')
       .then(then)
       .always(always)
@@ -33,9 +33,9 @@ describe('httpUtils', () => {
   })
 
   it('should be able to get with fail callback', () => {
-    let then = sinon.spy()
-    let err = sinon.spy()
-    let always = sinon.spy()
+    const then = sinon.spy()
+    const err = sinon.spy()
+    const always = sinon.spy()
     utils.getRequest('/some/path')
       .then(then)
       .catch(err)


### PR DESCRIPTION
- Using `const` instead of `let`
- Better variable names
- Using `triggerEvent()` method when possible

MINOR: using keydown instead of keyup.prevent for TimePicker (reducing jumping cursor while using keyboard)

@wxsms
