### PR TITLE
Try to avoid nexttick usage onfocus

### DIFF
--- a/src/components/timepicker/TimePicker.vue
+++ b/src/components/timepicker/TimePicker.vue
@@ -24,6 +24,7 @@
                  class="form-control text-center"
                  style="width: 50px"
                  @focus="selectInputValue"
+                 @mouseup.prevent="nope"
                  @keydown.prevent.up="changeTime(1, 1)"
                  @keydown.prevent.down="changeTime(1, 0)"
                  @wheel="onWheel($event, true)"
@@ -40,6 +41,7 @@
                  class="form-control text-center"
                  style="width: 50px"
                  @focus="selectInputValue"
+                 @mouseup.prevent="nope"
                  @keydown.prevent.up="changeTime(0, 1)"
                  @keydown.prevent.down="changeTime(0, 0)"
                  @wheel="onWheel($event, false)"
@@ -266,9 +268,11 @@
         this.$emit('input', new Date(time))
       },
       selectInputValue (e) {
-        this.$nextTick(() => {
-          e.target.setSelectionRange(0, 2)
-        })
+        e.target.setSelectionRange(0, 2)
+      },
+      nope (e) {
+        // Does nothing but we need to prevent the mouseup event or else we loose the selection made onfocus on Safari (Desktop & iOS)
+        // See various comments in https://stackoverflow.com/questions/3272089/programmatically-selecting-text-in-an-input-field-on-ios-devices-mobile-safari
       }
     }
   }

--- a/src/components/timepicker/TimePicker.vue
+++ b/src/components/timepicker/TimePicker.vue
@@ -24,7 +24,7 @@
                  class="form-control text-center"
                  style="width: 50px"
                  @focus="selectInputValue"
-                 @mouseup.prevent="nope"
+                 @mouseup.prevent
                  @keydown.prevent.up="changeTime(1, 1)"
                  @keydown.prevent.down="changeTime(1, 0)"
                  @wheel="onWheel($event, true)"
@@ -41,7 +41,7 @@
                  class="form-control text-center"
                  style="width: 50px"
                  @focus="selectInputValue"
-                 @mouseup.prevent="nope"
+                 @mouseup.prevent
                  @keydown.prevent.up="changeTime(0, 1)"
                  @keydown.prevent.down="changeTime(0, 0)"
                  @wheel="onWheel($event, false)"
@@ -268,11 +268,9 @@
         this.$emit('input', new Date(time))
       },
       selectInputValue (e) {
-        e.target.setSelectionRange(0, 2)
-      },
-      nope (e) {
-        // Does nothing but we need to prevent the mouseup event or else we loose the selection made onfocus on Safari (Desktop & iOS)
+        // mouseup should be prevented!
         // See various comments in https://stackoverflow.com/questions/3272089/programmatically-selecting-text-in-an-input-field-on-ios-devices-mobile-safari
+        e.target.setSelectionRange(0, 2)
       }
     }
   }

--- a/src/components/timepicker/TimePicker.vue
+++ b/src/components/timepicker/TimePicker.vue
@@ -23,8 +23,7 @@
                  pattern="\d*"
                  class="form-control text-center"
                  style="width: 50px"
-                 @focus="selectInputValue"
-                 @mouseup.prevent
+                 @mouseup="selectInputValue"
                  @keydown.prevent.up="changeTime(1, 1)"
                  @keydown.prevent.down="changeTime(1, 0)"
                  @wheel="onWheel($event, true)"
@@ -40,8 +39,7 @@
                  pattern="\d*"
                  class="form-control text-center"
                  style="width: 50px"
-                 @focus="selectInputValue"
-                 @mouseup.prevent
+                 @mouseup="selectInputValue"
                  @keydown.prevent.up="changeTime(0, 1)"
                  @keydown.prevent.down="changeTime(0, 0)"
                  @wheel="onWheel($event, false)"

--- a/test/unit/specs/TimePicker.spec.js
+++ b/test/unit/specs/TimePicker.spec.js
@@ -384,13 +384,13 @@ describe('TimePicker', () => {
     await vm.$nextTick()
     const hoursInput = vm.$el.querySelectorAll('input')[0]
     const hoursInputSpy = sinon.spy(hoursInput, 'setSelectionRange')
-    utils.triggerEvent(hoursInput, 'focus', {}, true, false)
+    utils.triggerEvent(hoursInput, 'focus', {}, true, true)
     await vm.$nextTick()
     sinon.assert.calledOnce(hoursInputSpy)
     hoursInput.setSelectionRange.restore()
     const minutesInput = vm.$el.querySelectorAll('input')[1]
     const minutesInputSpy = sinon.spy(minutesInput, 'setSelectionRange')
-    utils.triggerEvent(minutesInput, 'focus', {}, true, false)
+    utils.triggerEvent(minutesInput, 'focus', {}, true, true)
     await vm.$nextTick()
     sinon.assert.calledOnce(minutesInputSpy)
     minutesInput.setSelectionRange.restore()

--- a/test/unit/specs/TimePicker.spec.js
+++ b/test/unit/specs/TimePicker.spec.js
@@ -384,13 +384,13 @@ describe('TimePicker', () => {
     await vm.$nextTick()
     const hoursInput = vm.$el.querySelectorAll('input')[0]
     const hoursInputSpy = sinon.spy(hoursInput, 'setSelectionRange')
-    utils.triggerEvent(hoursInput, 'focus')
+    utils.triggerEvent(hoursInput, 'focus', {}, false, false)
     await vm.$nextTick()
     sinon.assert.calledOnce(hoursInputSpy)
     hoursInput.setSelectionRange.restore()
     const minutesInput = vm.$el.querySelectorAll('input')[1]
     const minutesInputSpy = sinon.spy(minutesInput, 'setSelectionRange')
-    utils.triggerEvent(minutesInput, 'focus')
+    utils.triggerEvent(minutesInput, 'focus', {}, false, false)
     await vm.$nextTick()
     sinon.assert.calledOnce(minutesInputSpy)
     minutesInput.setSelectionRange.restore()

--- a/test/unit/specs/TimePicker.spec.js
+++ b/test/unit/specs/TimePicker.spec.js
@@ -382,18 +382,18 @@ describe('TimePicker', () => {
       staticRenderFns: res.staticRenderFns
     }).$mount($div.get(0))
     await vm.$nextTick()
-    const hourInput = vm.$el.querySelectorAll('input')[0]
-    const hourInputSpy = sinon.spy(hourInput, 'setSelectionRange')
-    hourInput.focus()
+    const hoursInput = vm.$el.querySelectorAll('input')[0]
+    const hoursInputSpy = sinon.spy(hoursInput, 'setSelectionRange')
+    utils.triggerEvent(hoursInput, 'focus')
     await vm.$nextTick()
-    sinon.assert.calledOnce(hourInputSpy)
-    hourInput.setSelectionRange.restore()
-    const minuteInput = vm.$el.querySelectorAll('input')[1]
-    const minuteInputSpy = sinon.spy(minuteInput, 'setSelectionRange')
-    minuteInput.focus()
+    sinon.assert.calledOnce(hoursInputSpy)
+    hoursInput.setSelectionRange.restore()
+    const minutesInput = vm.$el.querySelectorAll('input')[1]
+    const minutesInputSpy = sinon.spy(minutesInput, 'setSelectionRange')
+    utils.triggerEvent(minutesInput, 'focus')
     await vm.$nextTick()
-    sinon.assert.calledOnce(minuteInputSpy)
-    minuteInput.setSelectionRange.restore()
+    sinon.assert.calledOnce(minutesInputSpy)
+    minutesInput.setSelectionRange.restore()
     vm.$destroy()
     $div.remove()
   })

--- a/test/unit/specs/TimePicker.spec.js
+++ b/test/unit/specs/TimePicker.spec.js
@@ -384,13 +384,13 @@ describe('TimePicker', () => {
     await vm.$nextTick()
     const hoursInput = vm.$el.querySelectorAll('input')[0]
     const hoursInputSpy = sinon.spy(hoursInput, 'setSelectionRange')
-    utils.triggerEvent(hoursInput, 'focus', {}, false, false)
+    utils.triggerEvent(hoursInput, 'focus', {}, true, false)
     await vm.$nextTick()
     sinon.assert.calledOnce(hoursInputSpy)
     hoursInput.setSelectionRange.restore()
     const minutesInput = vm.$el.querySelectorAll('input')[1]
     const minutesInputSpy = sinon.spy(minutesInput, 'setSelectionRange')
-    utils.triggerEvent(minutesInput, 'focus', {}, false, false)
+    utils.triggerEvent(minutesInput, 'focus', {}, true, false)
     await vm.$nextTick()
     sinon.assert.calledOnce(minutesInputSpy)
     minutesInput.setSelectionRange.restore()

--- a/test/unit/specs/TimePicker.spec.js
+++ b/test/unit/specs/TimePicker.spec.js
@@ -384,13 +384,13 @@ describe('TimePicker', () => {
     await vm.$nextTick()
     const hoursInput = vm.$el.querySelectorAll('input')[0]
     const hoursInputSpy = sinon.spy(hoursInput, 'setSelectionRange')
-    utils.triggerEvent(hoursInput, 'focus', {}, false, true)
+    hoursInput.focus() // utils.triggerEvent() doesn't work here
     await vm.$nextTick()
     sinon.assert.calledOnce(hoursInputSpy)
     hoursInput.setSelectionRange.restore()
     const minutesInput = vm.$el.querySelectorAll('input')[1]
     const minutesInputSpy = sinon.spy(minutesInput, 'setSelectionRange')
-    utils.triggerEvent(minutesInput, 'focus', {}, false, true)
+    minutesInput.focus() // utils.triggerEvent() doesn't work here
     await vm.$nextTick()
     sinon.assert.calledOnce(minutesInputSpy)
     minutesInput.setSelectionRange.restore()

--- a/test/unit/specs/TimePicker.spec.js
+++ b/test/unit/specs/TimePicker.spec.js
@@ -384,13 +384,13 @@ describe('TimePicker', () => {
     await vm.$nextTick()
     const hoursInput = vm.$el.querySelectorAll('input')[0]
     const hoursInputSpy = sinon.spy(hoursInput, 'setSelectionRange')
-    utils.triggerEvent(hoursInput, 'focus', {}, true, true)
+    utils.triggerEvent(hoursInput, 'focus', {}, false, true)
     await vm.$nextTick()
     sinon.assert.calledOnce(hoursInputSpy)
     hoursInput.setSelectionRange.restore()
     const minutesInput = vm.$el.querySelectorAll('input')[1]
     const minutesInputSpy = sinon.spy(minutesInput, 'setSelectionRange')
-    utils.triggerEvent(minutesInput, 'focus', {}, true, true)
+    utils.triggerEvent(minutesInput, 'focus', {}, false, true)
     await vm.$nextTick()
     sinon.assert.calledOnce(minutesInputSpy)
     minutesInput.setSelectionRange.restore()

--- a/test/unit/specs/TimePicker.spec.js
+++ b/test/unit/specs/TimePicker.spec.js
@@ -369,7 +369,7 @@ describe('TimePicker', () => {
     vm.$destroy()
   })
 
-  it('should be able to select input while focus', async () => {
+  it('should be able to select input content on mouseup', async () => {
     const res = Vue.compile('<time-picker v-model="time"/>')
     const $div = $('<div>').appendTo('body')
     const vm = new Vue({
@@ -384,13 +384,13 @@ describe('TimePicker', () => {
     await vm.$nextTick()
     const hoursInput = vm.$el.querySelectorAll('input')[0]
     const hoursInputSpy = sinon.spy(hoursInput, 'setSelectionRange')
-    hoursInput.focus() // utils.triggerEvent() doesn't work here
+    utils.triggerEvent(hoursInput, 'mouseup')
     await vm.$nextTick()
     sinon.assert.calledOnce(hoursInputSpy)
     hoursInput.setSelectionRange.restore()
     const minutesInput = vm.$el.querySelectorAll('input')[1]
     const minutesInputSpy = sinon.spy(minutesInput, 'setSelectionRange')
-    minutesInput.focus() // utils.triggerEvent() doesn't work here
+    utils.triggerEvent(minutesInput, 'mouseup')
     await vm.$nextTick()
     sinon.assert.calledOnce(minutesInputSpy)
     minutesInput.setSelectionRange.restore()


### PR DESCRIPTION
It seems that the `setSelection` reset on Safari is caused by the `mouseup` event.

Trying to avoid using nextTick

@wxsms


PS1: should we rename `nope` to `noop` ?
PS2: what do you prefer
a) Use the `prevent` modifier + `nope`
b) Define and use a new method called `prevent` ...