### PR TITLE
Typeahead no preselection and close dropdown with ESC

### DIFF
--- a/src/components/typeahead/Typeahead.vue
+++ b/src/components/typeahead/Typeahead.vue
@@ -81,6 +81,10 @@
       },
       target: {
         required: true
+      },
+      preselect: {
+        type: Boolean,
+        default: true
       }
     },
     data () {
@@ -173,7 +177,7 @@
           return
         }
         this.items = []
-        this.activeIndex = 0
+        this.activeIndex = this.preselect ? 0 : -1
         for (let i = 0, l = data.length; i < l; i++) {
           let item = data[i]
           let key = this.itemKey ? item[this.itemKey] : item
@@ -238,6 +242,9 @@
           switch (event.keyCode) {
             case 13:
               this.selectItem(this.items[this.activeIndex])
+              break
+            case 27:
+              this.open = false
               break
             case 38:
               this.activeIndex = this.activeIndex > 0 ? this.activeIndex - 1 : 0


### PR DESCRIPTION
Changes proposed in this pull request:

- Typeahead: Allow the possibility to choose if the first item in the dropdown should be pre-selected when you type something that has a match
- Typeahead: Allow the possibility of closing the dropdown by pressing ESC

@wxsms
