### PR TITLE
Typeahead value not retained with no preselected value

### DIFF
--- a/src/components/typeahead/Typeahead.vue
+++ b/src/components/typeahead/Typeahead.vue
@@ -233,7 +233,11 @@
         if (this.open) {
           switch (event.keyCode) {
             case 13:
-              this.selectItem(this.items[this.activeIndex])
+              if (this.activeIndex >= 0) {
+                this.selectItem(this.items[this.activeIndex])
+              } else {
+                this.open = false
+              }
               break
             case 27:
               this.open = false

--- a/src/components/typeahead/Typeahead.vue
+++ b/src/components/typeahead/Typeahead.vue
@@ -81,6 +81,10 @@
       },
       target: {
         required: true
+      },
+      preselect: {
+        type: Boolean,
+        default: true
       }
     },
     data () {
@@ -173,7 +177,7 @@
           return
         }
         this.items = []
-        this.activeIndex = 0
+        this.activeIndex = this.preselect ? 0 : -1
         for (let i = 0, l = data.length; i < l; i++) {
           let item = data[i]
           let key = this.itemKey ? item[this.itemKey] : item
@@ -238,6 +242,9 @@
           switch (event.keyCode) {
             case 13:
               this.selectItem(this.items[this.activeIndex])
+              break
+            case 27:
+              this.open = false
               break
             case 38:
               this.activeIndex = this.activeIndex > 0 ? this.activeIndex - 1 : 0


### PR DESCRIPTION
Fixes a bug where the Typeahead value written is not retained when pressing Enter while no dropdown value is selected.

@wxsms
