### PR TITLE
#129 `custom-classes` prop added to `MessageBox`.

### DIFF
--- a/docs/pages/components/MessageBox.md
+++ b/docs/pages/components/MessageBox.md
@@ -157,7 +157,7 @@ Name             | Type       | Default  | Required | Description
 `ok-type`        | String     | primary  |          | Button type of ok button.
 `cancel-text`    | String     |          |          | Text of cancel button.
 `cancel-type`    | String     | default  |          | Button type of cancel button.
-`custom-classes` | Array      | []       |          | Custom classes to modal.
+`custom-class`   | String     |          |          | Custom classes to modal.
 `backdrop`       | Boolean    | `false` if type is alert, otherwise `true` |          | Dismiss the modal by backdrop click.
 `validator`      | Function   |          |          | Custom validator function for prompt. Accepts the input value as param, returns the err msg (not valid) or null (valid)
 

--- a/docs/pages/components/MessageBox.md
+++ b/docs/pages/components/MessageBox.md
@@ -148,17 +148,18 @@ These props are used as `options` in the methods above.
 
 ### Props
 
-Name           | Type       | Default  | Required | Description
-----------     | ---------- | -------- | -------- | -----------------------
-`size`         | String     | sm       |          | The alternative modal sizes. Support: `lg` / `md` / `sm`.
-`title`        | String     |          |          | The modal title.
-`content`      | String     |          |          | The modal content.
-`ok-text`      | String     |          |          | Text of ok button.
-`ok-type`      | String     | primary  |          | Button type of ok button.
-`cancel-text`  | String     |          |          | Text of cancel button.
-`cancel-type`  | String     | default  |          | Button type of cancel button.
-`backdrop`     | Boolean    | `false` if type is alert, otherwise `true` |          | Dismiss the modal by backdrop click.
-`validator`    | Function   |          |          | Custom validator function for prompt. Accepts the input value as param, returns the err msg (not valid) or null (valid)
+Name             | Type       | Default  | Required | Description
+----------       | ---------- | -------- | -------- | -----------------------
+`size`           | String     | sm       |          | The alternative modal sizes. Support: `lg` / `md` / `sm`.
+`title`          | String     |          |          | The modal title.
+`content`        | String     |          |          | The modal content.
+`ok-text`        | String     |          |          | Text of ok button.
+`ok-type`        | String     | primary  |          | Button type of ok button.
+`cancel-text`    | String     |          |          | Text of cancel button.
+`cancel-type`    | String     | default  |          | Button type of cancel button.
+`custom-classes` | Array      | []       |          | Custom classes to modal.
+`backdrop`       | Boolean    | `false` if type is alert, otherwise `true` |          | Dismiss the modal by backdrop click.
+`validator`      | Function   |          |          | Custom validator function for prompt. Accepts the input value as param, returns the err msg (not valid) or null (valid)
 
 ## [messageBox.js](https://github.com/wxsms/uiv/blob/release/src/services/messagebox/messageBox.js)
 

--- a/src/services/messagebox/MessageBox.vue
+++ b/src/services/messagebox/MessageBox.vue
@@ -9,6 +9,7 @@
     :backdrop="closeOnBackdropClick"
     :cancel-text="cancelText"
     :ok-text="okText"
+    :class="customClasses"
     @hide="cb">
     <p>{{content}}</p>
     <div v-if="type===TYPES.PROMPT">
@@ -77,6 +78,11 @@
       validator: {
         type: Function,
         default: () => null
+      },
+      customClasses: {
+        type: Array,
+        required: false,
+        default: () => []
       }
     },
     data () {

--- a/src/services/messagebox/MessageBox.vue
+++ b/src/services/messagebox/MessageBox.vue
@@ -9,7 +9,7 @@
     :backdrop="closeOnBackdropClick"
     :cancel-text="cancelText"
     :ok-text="okText"
-    :class="customClasses"
+    :class="customClass"
     @hide="cb">
     <p>{{content}}</p>
     <div v-if="type===TYPES.PROMPT">
@@ -79,10 +79,9 @@
         type: Function,
         default: () => null
       },
-      customClasses: {
-        type: Array,
-        required: false,
-        default: () => []
+      customClass: {
+        type: String,
+        required: false
       }
     },
     data () {

--- a/src/services/messagebox/MessageBox.vue
+++ b/src/services/messagebox/MessageBox.vue
@@ -79,9 +79,7 @@
         type: Function,
         default: () => null
       },
-      customClass: {
-        required: false
-      }
+      customClass: null
     },
     data () {
       return {

--- a/src/services/messagebox/MessageBox.vue
+++ b/src/services/messagebox/MessageBox.vue
@@ -80,7 +80,6 @@
         default: () => null
       },
       customClass: {
-        type: String,
         required: false
       }
     },


### PR DESCRIPTION
Fixes #129 

Changes proposed in this pull request:

- `custom-classes` prop added to `MessageBox`.
- `customClasses` property can be passed with `options` parameter of `$alert`, `$confirm` and `$prompt`. 



@wxsms
