### PR TITLE
Add msg param to modal:before-close function

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -141,7 +141,7 @@
       },
       toggle (show, msg) {
         // skip the hiding while show===false & beforeClose returning falsely value
-        if (!show && isFunction(this.beforeClose) && !this.beforeClose()) {
+        if (!show && isFunction(this.beforeClose) && !this.beforeClose(msg)) {
           return
         }
         this.msg = msg


### PR DESCRIPTION
Add "msg" parameter to before-close function attribute in modal.

It's useful when you need to check the result of an api call before closing popup (avoid to close if there is an error for example).

Max 