### PR TITLE
FIX #162: impossible to reset TimePicker value at runtime

### DIFF
--- a/src/components/timepicker/TimePicker.vue
+++ b/src/components/timepicker/TimePicker.vue
@@ -151,26 +151,36 @@
         this.setTime()
       },
       hoursText (value) {
-        let hour = parseInt(value)
-        if (this.showMeridian) {
-          if (hour >= 1 && hour <= cutUpAmAndPm) {
-            if (this.meridian) {
-              this.hours = hour === cutUpAmAndPm ? 0 : hour
-            } else {
-              this.hours = hour === cutUpAmAndPm ? cutUpAmAndPm : hour + cutUpAmAndPm
+        if (this.hours === 0 && value === '') {
+          // Prevent a runtime reset from being overwritten
+          return
+        } else {
+          let hour = parseInt(value)
+          if (this.showMeridian) {
+            if (hour >= 1 && hour <= cutUpAmAndPm) {
+              if (this.meridian) {
+                this.hours = hour === cutUpAmAndPm ? 0 : hour
+              } else {
+                this.hours = hour === cutUpAmAndPm ? cutUpAmAndPm : hour + cutUpAmAndPm
+              }
             }
+          } else if (hour >= zero && hour <= maxHours) {
+            this.hours = hour
           }
-        } else if (hour >= zero && hour <= maxHours) {
-          this.hours = hour
+          this.setTime()
         }
-        this.setTime()
       },
       minutesText (value) {
-        let minutesStr = parseInt(value)
-        if (minutesStr >= zero && minutesStr <= maxMinutes) {
-          this.minutes = minutesStr
+        if (this.minutes === 0 && value === '') {
+          // Prevent a runtime reset from being overwritten
+          return
+        } else {
+          let minutesStr = parseInt(value)
+          if (minutesStr >= zero && minutesStr <= maxMinutes) {
+            this.minutes = minutesStr
+          }
+          this.setTime()
         }
-        this.setTime()
       }
     },
     methods: {

--- a/src/components/timepicker/TimePicker.vue
+++ b/src/components/timepicker/TimePicker.vue
@@ -154,33 +154,31 @@
         if (this.hours === 0 && value === '') {
           // Prevent a runtime reset from being overwritten
           return
-        } else {
-          let hour = parseInt(value)
-          if (this.showMeridian) {
-            if (hour >= 1 && hour <= cutUpAmAndPm) {
-              if (this.meridian) {
-                this.hours = hour === cutUpAmAndPm ? 0 : hour
-              } else {
-                this.hours = hour === cutUpAmAndPm ? cutUpAmAndPm : hour + cutUpAmAndPm
-              }
-            }
-          } else if (hour >= zero && hour <= maxHours) {
-            this.hours = hour
-          }
-          this.setTime()
         }
+        let hour = parseInt(value)
+        if (this.showMeridian) {
+          if (hour >= 1 && hour <= cutUpAmAndPm) {
+            if (this.meridian) {
+              this.hours = hour === cutUpAmAndPm ? 0 : hour
+            } else {
+              this.hours = hour === cutUpAmAndPm ? cutUpAmAndPm : hour + cutUpAmAndPm
+            }
+          }
+        } else if (hour >= zero && hour <= maxHours) {
+          this.hours = hour
+        }
+        this.setTime()
       },
       minutesText (value) {
         if (this.minutes === 0 && value === '') {
           // Prevent a runtime reset from being overwritten
           return
-        } else {
-          let minutesStr = parseInt(value)
-          if (minutesStr >= zero && minutesStr <= maxMinutes) {
-            this.minutes = minutesStr
-          }
-          this.setTime()
         }
+        let minutesStr = parseInt(value)
+        if (minutesStr >= zero && minutesStr <= maxMinutes) {
+          this.minutes = minutesStr
+        }
+        this.setTime()
       }
     },
     methods: {

--- a/test/specs/TimePicker.spec.js
+++ b/test/specs/TimePicker.spec.js
@@ -471,7 +471,7 @@ describe('TimePicker', () => {
     expect(minutesText.value).to.equal('00')
     expect(toggleBtn.textContent).to.equal('AM')
   })
-  it('should display empty fields when date gets resets at runtime', async () => {
+  it('should display empty fields when date is reset at runtime', async () => {
     const _vm = vm.$refs['time-picker-no-controls-example']
     await vm.$nextTick()
     // Set an invalid date at runtime (not via the initial config)

--- a/test/specs/TimePicker.spec.js
+++ b/test/specs/TimePicker.spec.js
@@ -471,4 +471,15 @@ describe('TimePicker', () => {
     expect(minutesText.value).to.equal('00')
     expect(toggleBtn.textContent).to.equal('AM')
   })
+  it('should display empty fields when date gets resets at runtime', async () => {
+    const _vm = vm.$refs['time-picker-no-controls-example']
+    await vm.$nextTick()
+    // Set an invalid date at runtime (not via the initial config)
+    _vm.time = new Date('')
+    await vm.$nextTick()
+    const hourText = _vm.$el.querySelectorAll('input')[0]
+    const minutesText = _vm.$el.querySelectorAll('input')[1]
+    expect(hourText.value).to.equal('')
+    expect(minutesText.value).to.equal('')
+  })
 })


### PR DESCRIPTION
### BUG FIX for #162 

### Any Breaking changes?
No breaking change detected at this time
