### PR TITLE
Fixes #191 - Fire before-change event in tabs components

### DIFF
--- a/docs/pages/components/Tabs.md
+++ b/docs/pages/components/Tabs.md
@@ -237,8 +237,8 @@ An example how to prevent tab display when `before-change` callback return `fals
       }
     },
     methods: {
-      onBeforeChange (payload) {
-        (payload.index > 1) ? payload.allow(false) : payload.allow(true)
+      onBeforeChange (index, done) {
+        (index > 1) ? done(false) : done()
       }
     }
   }
@@ -269,10 +269,10 @@ Name        | Description
 
 ### Events
 
-Name            | Params  | Description
---------------- | ------- | ---------------
-`change`        | index   | Fire after active tab changed, with the active index.
-`before-change` | payload | Fire before active tab changed. Payload: { allow: function(Boolean), index: integer }. Index - the index of clicked tab. Call payload.allow(true) in your handler to allow tab display. Call payload.allow(false) to prevent tab display.
+Name            | Params      | Description
+--------------- | ----------- | ---------------
+`change`        | index       | Fire after active tab changed, with the active index.
+`before-change` | index, done | Fire before active tab changed, with the `index` of clicked tab and `done()` callback. Calling `done()` allow tab to display. Calling `done(err)`, where `err` is any value, prevent display of the tab.
 
 ## [Tab](https://github.com/wxsms/uiv/blob/master/src/components/tabs/Tab.vue)
 

--- a/docs/pages/components/Tabs.md
+++ b/docs/pages/components/Tabs.md
@@ -209,6 +209,43 @@ An example that generate closable tabs using `v-for`:
 <!-- tabs-dynamic-example.vue -->
 ```
 
+## Callback on `before-change` event
+
+An example how to prevent tab display when `before-change` callback return `false`
+
+```html
+<template>
+  <section>
+    <tabs v-model="index" @before-change="onBeforeChange">
+      <tab title="Home (allowed)">
+        <p>Home tab.</p>
+      </tab>
+      <tab title="Allowed">
+        <p>Allowed</p>
+      </tab>
+      <tab title="Denied">
+        <p>Denied</p>
+      </tab>
+    </tabs>
+  </section>
+</template>
+<script>
+  export default {
+    data () {
+      return {
+        index: 0
+      }
+    },
+    methods: {
+      onBeforeChange (payload) {
+        (payload.index > 1) ? payload.allow(false) : payload.allow(true)
+      }
+    }
+  }
+</script>
+<!-- tabs-before-change-example.vue -->
+```
+
 # API Reference
 
 ## [Tabs](https://github.com/wxsms/uiv/blob/master/src/components/tabs/Tabs.vue)
@@ -232,9 +269,10 @@ Name        | Description
 
 ### Events
 
-Name        | Params | Description
------------ | ------ | ---------------
-`change`    | index  | Fire after active tab changed, with the active index.
+Name            | Params  | Description
+--------------- | ------- | ---------------
+`change`        | index   | Fire after active tab changed, with the active index.
+`before-change` | payload | Fire before active tab changed. Payload: { allow: function(Boolean), index: integer }. Index - the index of clicked tab. Call payload.allow(true) in your handler to allow tab display. Call payload.allow(false) to prevent tab display.
 
 ## [Tab](https://github.com/wxsms/uiv/blob/master/src/components/tabs/Tab.vue)
 

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -58,6 +58,7 @@
         immediate: true,
         handler (value) {
           if (isNumber(value)) {
+            this.prevIndex = this.activeIndex
             this.activeIndex = value
             this.selectCurrent()
           }
@@ -71,9 +72,6 @@
           }
         })
         this.selectCurrent()
-      },
-      activeIndex (newIndex, oldIndex) {
-        this.prevIndex = oldIndex
       }
     },
     computed: {
@@ -133,13 +131,14 @@
         if (found) {
           const self = this
           if (typeof this.$listeners['before-change'] === 'function') {
-            this.beforeChange(this.activeIndex).then((result) => {
-              if (result) {
-                self.$emit('change', this.activeIndex)
-              } else {
+            this.$emit('before-change', this.activeIndex, (result) => {
+              let event = 'change'
+              if (typeof result !== 'undefined') {
                 self.activeIndex = self.prevIndex
+                event = 'input'
               }
               self.tabs[self.activeIndex].active = true
+              self.$emit(event, self.activeIndex)
             })
           } else {
             this.tabs[this.activeIndex].active = true
@@ -152,35 +151,11 @@
           if (isNumber(this.value)) {
             this.$emit('input', index)
           } else {
+            this.prevIndex = this.activeIndex
             this.activeIndex = index
             this.selectCurrent()
           }
         }
-      },
-      beforeChange (index) {
-        const self = this
-        let allowed = true
-        let callbackPromise = new Promise((resolve, reject) => {
-          self.$emit(
-            'before-change',
-            {
-              allow: (result) => {
-                if (typeof result === typeof true) {
-                  allowed = allowed && result
-                }
-                resolve(allowed)
-              },
-              index: index
-            }
-          )
-        })
-        let timeoutPromise = new Promise((resolve, reject) => {
-          let timeout = setTimeout(() => {
-            clearTimeout(timeout)
-            resolve(allowed)
-          }, 500)
-        })
-        return Promise.race([callbackPromise, timeoutPromise])
       }
     }
   }

--- a/test/specs/Tabs.spec.js
+++ b/test/specs/Tabs.spec.js
@@ -291,4 +291,46 @@ describe('Tabs', () => {
     expect(activeContent.length).to.equal(1)
     expect(activeContent[0].textContent).to.contain('Tab 4')
   })
+
+  it('should not display tab if before-change callback return false', async () => {
+    const _vm = vm.$refs['tabs-before-change-example']
+    const $el = $(_vm.$el)
+    const nav = $el.find('.nav-tabs').get(0)
+    const content = $el.find('.tab-content').get(0)
+    await vm.$nextTick()
+    await vm.$nextTick()
+    expect(nav.querySelectorAll('li').length).to.equal(3)
+    // check active tab
+    let activeTab = nav.querySelectorAll('.active')
+    expect(activeTab.length).to.equal(1)
+    expect(activeTab[0].querySelector('a').textContent).to.equal('Home (allowed)')
+    // check active content
+    let activeContent = content.querySelectorAll('.tab-pane.active')
+    expect(activeContent.length).to.equal(1)
+    expect(activeContent[0].textContent).to.contain('Home tab')
+    // click on allowed tab #2
+    utils.triggerEvent(nav.querySelectorAll('li > a')[1], 'click')
+    await vm.$nextTick()
+    await utils.sleep(350)
+    // check active tab
+    activeTab = nav.querySelectorAll('.active')
+    expect(activeTab.length).to.equal(1)
+    expect(activeTab[0].querySelector('a').textContent).to.equal('Allowed')
+    // check active content
+    activeContent = content.querySelectorAll('.tab-pane.active')
+    expect(activeContent.length).to.equal(1)
+    expect(activeContent[0].textContent).to.contain('Allowed')
+    // click on denied tab #3
+    utils.triggerEvent(nav.querySelectorAll('li > a')[2], 'click')
+    await vm.$nextTick()
+    await utils.sleep(350)
+    // check active tab
+    activeTab = nav.querySelectorAll('.active')
+    expect(activeTab.length).to.equal(1)
+    expect(activeTab[0].querySelector('a').textContent).to.equal('Allowed')
+    // check active content
+    activeContent = content.querySelectorAll('.tab-pane.active')
+    expect(activeContent.length).to.equal(1)
+    expect(activeContent[0].textContent).to.contain('Allowed')
+  })
 })


### PR DESCRIPTION
Fire before-change event in tabs components. If event handler return false - not show clicked tab

### Is this a bug fix or enhancement?
Enhancement

### Is there a related issue?
Fixes #191 

### Any Breaking changes?
No
