### PR TITLE
Fix translated first day of a week (monday) to pt-BR

### DIFF
--- a/src/locale/lang/pt-BR.js
+++ b/src/locale/lang/pt-BR.js
@@ -17,7 +17,7 @@ export default {
       month11: 'Novembro',
       month12: 'Dezembro',
       year: 'Ano',
-      week1: 'Mês',
+      week1: 'Seg',
       week2: 'Ter',
       week3: 'Qua',
       week4: 'Qui',


### PR DESCRIPTION
This is a enhancement to fix monday in portuguese on datepicker.
There is no issue related.
No breaking changes.

[]s


