### PR TITLE
Add input event to Typeahead documentation

### DIFF
--- a/docs/pages/components/Typeahead.md
+++ b/docs/pages/components/Typeahead.md
@@ -257,3 +257,4 @@ Name           | Description
 `loading`      | Async loading.
 `loaded`       | Async load complete.
 `loaded-error` | Async load complete with error.
+`input`        | Item selected


### PR DESCRIPTION
The Typeahead component emits an 'input' event with the selected item.

### Is this a bug fix or enhancement?

Documentation enhancement

### Is there a related issue?

No

### Any Breaking changes?

No
