### PR TITLE
Enhancement: setting delay to show/hide popover

### DIFF
--- a/docs/pages/components/Popover.md
+++ b/docs/pages/components/Popover.md
@@ -140,13 +140,13 @@ Set `enable` prop to `false` to disable a popover.
 Set `enable` prop to `false` to disable a popover.
 
 ```html
-<popover title="Title" :hideTransitionDuration='1000' :showTransitionDuration='3000' trigger='hover'>
+<popover title="Title" :hideDelay='1000' :showDelay='3000' trigger='hover'>
   <btn type="primary">Hover</btn>
   <template slot="popover">
     <h1>Hello world!</h1>
   </template>
 </popover>
-<!-- popover-duration.vue -->
+<!-- popover-delay.vue -->
 ```
 
 # API Reference

--- a/docs/pages/components/Popover.md
+++ b/docs/pages/components/Popover.md
@@ -135,6 +135,20 @@ Set `enable` prop to `false` to disable a popover.
 <!-- popover-disable.vue -->
 ```
 
+## Change duration
+
+Set `enable` prop to `false` to disable a popover.
+
+```html
+<popover title="Title" :hideTransitionDuration='1000' :showTransitionDuration='3000' trigger='hover'>
+  <btn type="primary">Hover</btn>
+  <template slot="popover">
+    <h1>Hello world!</h1>
+  </template>
+</popover>
+<!-- popover-duration.vue -->
+```
+
 # API Reference
 
 ## [Popover](https://github.com/wxsms/uiv/blob/master/src/components/popover/Popover.vue)

--- a/docs/pages/components/Popover.md
+++ b/docs/pages/components/Popover.md
@@ -135,12 +135,12 @@ Set `enable` prop to `false` to disable a popover.
 <!-- popover-disable.vue -->
 ```
 
-## Change duration
+## Change the display duration
 
-Set `enable` prop to `false` to disable a popover.
+Set `show-delay`/`hide-delay` (ms), to delay the showing/hiding of the popover.
 
 ```html
-<popover title="Title" :hideDelay='1000' :showDelay='3000' trigger='hover'>
+<popover title="Title" :hideDelay='1000' :showDelay='2000' trigger='hover'>
   <btn type="primary">Hover</btn>
   <template slot="popover">
     <h1>Hello world!</h1>
@@ -169,6 +169,8 @@ Name                  | Type       | Default       | Required | Description
 `trigger`             | String     | outside-click |          | The popover trigger event, support `hover` / `focus` / `hover-focus` / `click` / `outside-click` / `manual`
 `append-to`           | String     | body          |          | Element selector that the popover append to.
 `transition-duration` | Number     | 150           |          | The popover show / hide transition time in ms.
+`show-delay`          | Number     | 0             |          | Delay showing the Popover (ms).
+`hide-delay`          | Number     | 0             |          | Delay hidding the Popover (ms).
 
 ### Slots
 

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -205,7 +205,7 @@ export default {
       }
     },
     hide () {
-      if (this.hideTimeoutId > 0) {
+      if (this.showTimeoutId > 0) {
         clearTimeout(this.showTimeoutId)
         this.showTimeoutId = 0
       }
@@ -255,4 +255,4 @@ export default {
       }, 20) // 20ms make firefox happy
     }
   }
-}
+}1000

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -38,6 +38,10 @@ export default {
       type: String,
       default: 'body'
     },
+    transitionDuration: {
+      type: Number,
+      default: 150
+    },
     hideDelay: {
       type: Number,
       default: 150
@@ -234,10 +238,12 @@ export default {
         clearTimeout(this.hideTimeoutId)
         this.hideTimeoutId = setTimeout(() => {
           removeClass(this.$refs.popup, SHOW_CLASS)
-          removeFromDom(this.$refs.popup)
-          this.hideTimeoutId = 0
-          this.$emit('input', false)
-          this.$emit('hide')
+          setTimeout(() => {
+            removeFromDom(this.$refs.popup)
+            this.hideTimeoutId = 0
+            this.$emit('input', false)
+            this.$emit('hide')
+          }, this.transitionDuration)
         }, this.hideDelay)
       }
     },

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -192,13 +192,11 @@ export default {
     show () {
       if (this.enable && this.triggerEl && this.isNotEmpty() && !this.isShown()) {
         let popup = this.$refs.popup
-
         const popUpAppendedContainer = this.hideTimeoutId > 0 // weird condition
         if (popUpAppendedContainer) {
           clearTimeout(this.hideTimeoutId)
           this.hideTimeoutId = 0
         }
-
         this.showTimeoutId = setTimeout(() => {
           // add to dom
           if (!popUpAppendedContainer) {
@@ -207,7 +205,6 @@ export default {
             container.appendChild(popup)
             this.resetPosition()
           }
-
           addClass(popup, SHOW_CLASS)
           this.$emit('input', true)
           this.$emit('show')

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -38,7 +38,11 @@ export default {
       type: String,
       default: 'body'
     },
-    transitionDuration: {
+    hideTransitionDuration: {
+      type: Number,
+      default: 150
+    },
+    showTransitionDuration: {
       type: Number,
       default: 150
     },
@@ -55,7 +59,7 @@ export default {
   data () {
     return {
       triggerEl: null,
-      timeoutId: 0
+      hideTimeoutId: 0
     }
   },
   watch: {
@@ -183,21 +187,29 @@ export default {
     show () {
       if (this.enable && this.triggerEl && this.isNotEmpty() && !this.isShown()) {
         let popup = this.$refs.popup
-        if (this.timeoutId > 0) {
-          clearTimeout(this.timeoutId)
-          this.timeoutId = 0
+        if (this.hideTimeoutId > 0) {
+          clearTimeout(this.hideTimeoutId)
+          this.hideTimeoutId = 0
         } else {
           popup.className = `${this.name} ${this.placement} fade`
           let container = document.querySelector(this.appendTo)
           container.appendChild(popup)
           this.resetPosition()
         }
-        addClass(popup, SHOW_CLASS)
-        this.$emit('input', true)
-        this.$emit('show')
+
+        this.showTimeoutId = setTimeout(() => {
+          addClass(popup, SHOW_CLASS)
+          this.$emit('input', true)
+          this.$emit('show')
+        }, this.showTransitionDuration)
       }
     },
     hide () {
+      if (this.hideTimeoutId > 0) {
+        clearTimeout(this.showTimeoutId)
+        this.showTimeoutId = 0
+      }
+
       if (!this.isShown()) {
         return
       }
@@ -213,14 +225,14 @@ export default {
     },
     $hide () {
       if (this.isShown()) {
-        clearTimeout(this.timeoutId)
-        removeClass(this.$refs.popup, SHOW_CLASS)
-        this.timeoutId = setTimeout(() => {
+        clearTimeout(this.hideTimeoutId)
+        this.hideTimeoutId = setTimeout(() => {
+          removeClass(this.$refs.popup, SHOW_CLASS)
           removeFromDom(this.$refs.popup)
-          this.timeoutId = 0
+          this.hideTimeoutId = 0
           this.$emit('input', false)
           this.$emit('hide')
-        }, this.transitionDuration)
+        }, this.hideTransitionDuration)
       }
     },
     isShown () {

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -187,17 +187,23 @@ export default {
     show () {
       if (this.enable && this.triggerEl && this.isNotEmpty() && !this.isShown()) {
         let popup = this.$refs.popup
-        if (this.hideTimeoutId > 0) {
+
+        const popUpAppendedContainer = this.hideTimeoutId > 0 // weird condition
+        if (popUpAppendedContainer) {
           clearTimeout(this.hideTimeoutId)
           this.hideTimeoutId = 0
-        } else {
-          popup.className = `${this.name} ${this.placement} fade`
-          let container = document.querySelector(this.appendTo)
-          container.appendChild(popup)
-          this.resetPosition()
         }
 
         this.showTimeoutId = setTimeout(() => {
+
+          // add to dom
+          if (!popUpAppendedContainer) {
+            popup.className = `${this.name} ${this.placement} fade`
+            let container = document.querySelector(this.appendTo)
+            container.appendChild(popup)
+            this.resetPosition()
+          }
+
           addClass(popup, SHOW_CLASS)
           this.$emit('input', true)
           this.$emit('show')
@@ -255,4 +261,4 @@ export default {
       }, 20) // 20ms make firefox happy
     }
   }
-}1000
+}

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -64,7 +64,8 @@ export default {
     return {
       triggerEl: null,
       hideTimeoutId: 0,
-      showTimeoutId: 0
+      showTimeoutId: 0,
+      transitionTimeoutId: 0
     }
   },
   watch: {
@@ -197,6 +198,10 @@ export default {
           clearTimeout(this.hideTimeoutId)
           this.hideTimeoutId = 0
         }
+        if (this.transitionTimeoutId > 0) {
+          clearTimeout(this.transitionTimeoutId)
+          this.transitionTimeoutId = 0
+        }
         this.showTimeoutId = setTimeout(() => {
           // add to dom
           if (!popUpAppendedContainer) {
@@ -234,11 +239,12 @@ export default {
       if (this.isShown()) {
         clearTimeout(this.hideTimeoutId)
         this.hideTimeoutId = setTimeout(() => {
+          this.hideTimeoutId = 0
           removeClass(this.$refs.popup, SHOW_CLASS)
           // gives fade out time
-          setTimeout(() => {
+          this.transitionTimeoutId = setTimeout(() => {
+            this.transitionTimeoutId = 0
             removeFromDom(this.$refs.popup)
-            this.hideTimeoutId = 0
             this.$emit('input', false)
             this.$emit('hide')
           }, this.transitionDuration)

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -38,11 +38,11 @@ export default {
       type: String,
       default: 'body'
     },
-    hideTransitionDuration: {
+    hideDelay: {
       type: Number,
       default: 150
     },
-    showTransitionDuration: {
+    showDelay: {
       type: Number,
       default: 150
     },
@@ -59,7 +59,8 @@ export default {
   data () {
     return {
       triggerEl: null,
-      hideTimeoutId: 0
+      hideTimeoutId: 0,
+      showTimeoutId: 0
     }
   },
   watch: {
@@ -195,7 +196,6 @@ export default {
         }
 
         this.showTimeoutId = setTimeout(() => {
-
           // add to dom
           if (!popUpAppendedContainer) {
             popup.className = `${this.name} ${this.placement} fade`
@@ -207,7 +207,7 @@ export default {
           addClass(popup, SHOW_CLASS)
           this.$emit('input', true)
           this.$emit('show')
-        }, this.showTransitionDuration)
+        }, this.showDelay)
       }
     },
     hide () {
@@ -238,7 +238,7 @@ export default {
           this.hideTimeoutId = 0
           this.$emit('input', false)
           this.$emit('hide')
-        }, this.hideTransitionDuration)
+        }, this.hideDelay)
       }
     },
     isShown () {

--- a/src/mixins/popupMixin.js
+++ b/src/mixins/popupMixin.js
@@ -44,11 +44,11 @@ export default {
     },
     hideDelay: {
       type: Number,
-      default: 150
+      default: 0
     },
     showDelay: {
       type: Number,
-      default: 150
+      default: 0
     },
     enable: {
       type: Boolean,
@@ -238,6 +238,7 @@ export default {
         clearTimeout(this.hideTimeoutId)
         this.hideTimeoutId = setTimeout(() => {
           removeClass(this.$refs.popup, SHOW_CLASS)
+          // gives fade out time
           setTimeout(() => {
             removeFromDom(this.$refs.popup)
             this.hideTimeoutId = 0

--- a/test/index.js
+++ b/test/index.js
@@ -14,5 +14,5 @@ Vue.use(uiv)
 Function.prototype.bind = require('function-bind')
 
 // require all test files (files that ends with .spec.js)
-const testsContext = require.context('./specs', true, /\.spec$/)
+const testsContext = require.context('./specs', true, /Popover\.spec$/)
 testsContext.keys().forEach(testsContext)

--- a/test/index.js
+++ b/test/index.js
@@ -14,5 +14,5 @@ Vue.use(uiv)
 Function.prototype.bind = require('function-bind')
 
 // require all test files (files that ends with .spec.js)
-const testsContext = require.context('./specs', true, /Popover\.spec$/)
+const testsContext = require.context('./specs', true, /\.spec$/)
 testsContext.keys().forEach(testsContext)

--- a/test/specs/Popover.spec.js
+++ b/test/specs/Popover.spec.js
@@ -22,397 +22,421 @@ describe('Popover', () => {
     $('body').css('text-align', '').css('padding-top', '')
   })
 
-  it('should be ok to render if no trigger present', async () => {
-    const Constructor = Vue.extend(Popover)
-    const vm = new Constructor().$mount()
-    await vm.$nextTick()
-    $(vm.$el).remove()
-    vm.$destroy()
-  })
+  // it('should be ok to render if no trigger present', async () => {
+  //   const Constructor = Vue.extend(Popover)
+  //   const vm = new Constructor().$mount()
+  //   await vm.$nextTick()
+  //   $(vm.$el).remove()
+  //   vm.$destroy()
+  // })
 
-  it('should be able to show popover on init', async () => {
-    const res = Vue.compile('<popover v-model="show" title="123"><button data-role="trigger"></button></popover>')
+  // it('should be able to show popover on init', async () => {
+  //   const res = Vue.compile('<popover v-model="show" title="123"><button data-role="trigger"></button></popover>')
+  //   const _vm = new Vue({
+  //     data () {
+  //       return {
+  //         show: true
+  //       }
+  //     },
+  //     components: {Popover},
+  //     render: res.render,
+  //     staticRenderFns: res.staticRenderFns
+  //   }).$mount()
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   $(_vm.$el).remove()
+  //   $('.popover').remove()
+  //   _vm.$destroy()
+  // })
+
+  // it('should be able to use popover directive', async () => {
+  //   const res = Vue.compile('<btn v-popover="msg"></btn>')
+  //   const _vm = new Vue({
+  //     data () {
+  //       return {
+  //         msg: {title: 'title', content: 'content'}
+  //       }
+  //     },
+  //     render: res.render,
+  //     staticRenderFns: res.staticRenderFns
+  //   }).$mount()
+  //   await _vm.$nextTick()
+  //   const trigger = _vm.$el
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   let popover = document.querySelector('.popover')
+  //   expect(popover).to.exist
+  //   expect(popover.querySelector('.popover-title').innerText).to.equal('title')
+  //   expect(popover.querySelector('.popover-content').innerText).to.equal('content')
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   // this should work
+  //   _vm.msg = {title: 'title2', content: 'content2'}
+  //   await _vm.$nextTick()
+  //   await _vm.$nextTick()
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   popover = document.querySelector('.popover')
+  //   expect(popover).to.exist
+  //   expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
+  //   expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   // this should not work
+  //   _vm.$set(_vm.msg, 'title', 'title3')
+  //   await _vm.$nextTick()
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   popover = document.querySelector('.popover')
+  //   expect(popover).to.exist
+  //   expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
+  //   expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
+  //   _vm.$destroy()
+  // })
+
+  // it('directive with invalid modifiers should be ok', async () => {
+  //   // invalid modifier should be ok
+  //   const res = Vue.compile('<btn v-popover.test1.test2="msg"></btn>')
+  //   const _vm = new Vue({
+  //     data () {
+  //       return {
+  //         msg: {title: 'title', content: 'content'}
+  //       }
+  //     },
+  //     render: res.render,
+  //     staticRenderFns: res.staticRenderFns
+  //   }).$mount()
+  //   await _vm.$nextTick()
+  //   const trigger = _vm.$el
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   const popover = document.querySelector('.popover')
+  //   expect(popover).to.exist
+  //   expect(popover.querySelector('.popover-title').innerText).to.equal('title')
+  //   expect(popover.querySelector('.popover-content').innerText).to.equal('content')
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   _vm.$destroy()
+  // })
+
+  // it('should not show popover with no title and content', async () => {
+  //   const res = Vue.compile('<popover v-model="show"><button data-role="trigger"></button></popover>')
+  //   const _vm = new Vue({
+  //     data () {
+  //       return {
+  //         show: true
+  //       }
+  //     },
+  //     components: {Popover},
+  //     render: res.render,
+  //     staticRenderFns: res.staticRenderFns
+  //   }).$mount()
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   $(_vm.$el).remove()
+  //   $('.popover').remove()
+  //   _vm.$destroy()
+  // })
+
+  // it('should be able to use custom target', async () => {
+  //   const res = Vue.compile('<div><button ref="btn" type="button">btn</button><popover :target="btn" trigger="focus" title="123"></popover></div>')
+  //   const _vm = new Vue({
+  //     data () {
+  //       return {
+  //         btn: null
+  //       }
+  //     },
+  //     mounted () {
+  //       this.btn = this.$refs.btn
+  //     },
+  //     components: {Popover},
+  //     render: res.render,
+  //     staticRenderFns: res.staticRenderFns
+  //   }).$mount()
+  //   const $el = $(_vm.$el).appendTo('body')
+  //   await _vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   utils.triggerEvent(_vm.btn, 'focus')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   $el.remove()
+  //   $('.popover').remove()
+  //   _vm.$destroy()
+  // })
+
+  // it('should be able to show popover on click', async () => {
+  //   const _vm = vm.$refs['popover-example']
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to change trigger to manual', async () => {
+  //   const _vm = vm.$refs['popover-manual-trigger']
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   _vm.show = true
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   _vm.show = false
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able change trigger to hover-focus', async () => {
+  //   const _vm = vm.$refs['popover-triggers']
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   // matches don't work in here
+  //   const savedMatches = Element.prototype.matches
+  //   Element.prototype.matches = () => true
+  //   const trigger = _vm.$el.querySelectorAll('button')[3]
+  //   utils.triggerEvent(trigger, 'focus')
+  //   await utils.sleep(300)
+  //   Element.prototype.matches = savedMatches
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   utils.triggerEvent(trigger, 'blur')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to change trigger to click', async () => {
+  //   const _vm = vm.$refs['popover-triggers']
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   const trigger = _vm.$el.querySelectorAll('button')[4]
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to change trigger to hover', async () => {
+  //   const _vm = vm.$refs['popover-triggers']
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   const trigger = _vm.$el.querySelectorAll('button')[1]
+  //   utils.triggerEvent(trigger, 'mouseenter')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   utils.triggerEvent(trigger, 'mouseleave')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to toggle correctly on fast click', async () => {
+  //   const _vm = vm.$refs['popover-triggers']
+  //   const button = _vm.$el.querySelectorAll('button')[4]
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   utils.triggerEvent(button, 'click')
+  //   utils.triggerEvent(button, 'click')
+  //   utils.triggerEvent(button, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   utils.triggerEvent(button, 'click')
+  //   utils.triggerEvent(button, 'click')
+  //   utils.triggerEvent(button, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to change trigger to outside-click', async () => {
+  //   const _vm = vm.$refs['popover-triggers']
+  //   const button = _vm.$el.querySelectorAll('button')[0]
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   utils.triggerEvent(button, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   document.body.click()
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to disable', async () => {
+  //   const _vm = vm.$refs['popover-disable']
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to hide title', async () => {
+  //   const _vm = vm.$refs['popover-with-empty-title']
+  //   await vm.$nextTick()
+  //   const trigger = _vm.$el.querySelector('button')
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   expect(document.querySelector('.popover .popover-title').style.display).to.equal('none')
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to change placement to top', async () => {
+  //   const _vm = vm.$refs['popover-placements']
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   const trigger = _vm.$el.querySelectorAll('button')[1]
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   const popover = document.querySelector('.popover')
+  //   expect(popover).to.exist
+  //   expect(popover.className).to.contain('top')
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to change placement to bottom', async () => {
+  //   const _vm = vm.$refs['popover-placements']
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   const trigger = _vm.$el.querySelectorAll('button')[2]
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   const popover = document.querySelector('.popover')
+  //   expect(popover).to.exist
+  //   expect(popover.className).to.contain('bottom')
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to change placement to left', async () => {
+  //   const _vm = vm.$refs['popover-placements']
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   const trigger = _vm.$el.querySelectorAll('button')[0]
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   const popover = document.querySelector('.popover')
+  //   expect(popover).to.exist
+  //   expect(popover.className).to.contain('left')
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to change placement to right', async () => {
+  //   const _vm = vm.$refs['popover-placements']
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   const trigger = _vm.$el.querySelectorAll('button')[3]
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   const popover = document.querySelector('.popover')
+  //   expect(popover).to.exist
+  //   expect(popover.className).to.contain('right')
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  // })
+
+  // it('should be able to change trigger in runtime', async () => {
+  //   const res = Vue.compile('<popover title="123" :trigger="trigger"><button data-role="trigger"></button></popover>')
+  //   const _vm = new Vue({
+  //     data () {
+  //       return {
+  //         trigger: 'focus'
+  //       }
+  //     },
+  //     components: {Popover},
+  //     render: res.render,
+  //     staticRenderFns: res.staticRenderFns
+  //   }).$mount()
+  //   const $el = $(_vm.$el).appendTo('body')
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   await _vm.$nextTick()
+  //   const trigger = _vm.$el.querySelector('button')
+  //   utils.triggerEvent(trigger, 'focus')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   _vm.trigger = 'click'
+  //   await _vm.$nextTick()
+  //   utils.triggerEvent(trigger, 'blur')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   $el.remove()
+  //   _vm.$destroy()
+  // })
+
+  // it('should be able to change content in runtime', async () => {
+  //   const res = Vue.compile('<popover :content="msg" trigger="click"><btn>123</btn></popover>')
+  //   const vm = new Vue({
+  //     data () {
+  //       return {
+  //         msg: 'text'
+  //       }
+  //     },
+  //     render: res.render,
+  //     staticRenderFns: res.staticRenderFns
+  //   }).$mount()
+  //   const $el = $(vm.$el).appendTo('body')
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   await vm.$nextTick()
+  //   vm.msg = 'text2'
+  //   await vm.$nextTick()
+  //   await vm.$nextTick()
+  //   const trigger = vm.$el.querySelector('button')
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   expect(document.querySelector('.popover-content').innerText).to.equal('text2')
+  //   const topBefore = document.querySelector('.popover').style.top
+  //   vm.msg = 'This is a very very long text. This is a very very long text. This is a very very long text'
+  //   await vm.$nextTick()
+  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
+  //   expect(document.querySelector('.popover-content').innerText).to.contain('This is a very very long text')
+  //   await vm.$nextTick()
+  //   const topAfter = document.querySelector('.popover').style.top
+  //   expect(topAfter).not.equal(topBefore)
+  //   utils.triggerEvent(trigger, 'click')
+  //   await utils.sleep(300)
+  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
+  //   vm.msg = ''
+  //   await vm.$nextTick()
+  //   $el.remove()
+  //   vm.$destroy()
+  // })
+
+  it('should be able to show/hide on specified delay', async function () {
+    const res = Vue.compile('<popover :showDelay="300" :hideDelay="400" trigger="hover" title="123"><button></button></popover>')
     const _vm = new Vue({
-      data () {
-        return {
-          show: true
-        }
-      },
       components: {Popover},
       render: res.render,
       staticRenderFns: res.staticRenderFns
     }).$mount()
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    $(_vm.$el).remove()
-    $('.popover').remove()
-    _vm.$destroy()
-  })
-
-  it('should be able to use popover directive', async () => {
-    const res = Vue.compile('<btn v-popover="msg"></btn>')
-    const _vm = new Vue({
-      data () {
-        return {
-          msg: {title: 'title', content: 'content'}
-        }
-      },
-      render: res.render,
-      staticRenderFns: res.staticRenderFns
-    }).$mount()
-    await _vm.$nextTick()
-    const trigger = _vm.$el
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    let popover = document.querySelector('.popover')
-    expect(popover).to.exist
-    expect(popover.querySelector('.popover-title').innerText).to.equal('title')
-    expect(popover.querySelector('.popover-content').innerText).to.equal('content')
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    // this should work
-    _vm.msg = {title: 'title2', content: 'content2'}
-    await _vm.$nextTick()
-    await _vm.$nextTick()
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    popover = document.querySelector('.popover')
-    expect(popover).to.exist
-    expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
-    expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    // this should not work
-    _vm.$set(_vm.msg, 'title', 'title3')
-    await _vm.$nextTick()
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    popover = document.querySelector('.popover')
-    expect(popover).to.exist
-    expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
-    expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
-    _vm.$destroy()
-  })
-
-  it('directive with invalid modifiers should be ok', async () => {
-    // invalid modifier should be ok
-    const res = Vue.compile('<btn v-popover.test1.test2="msg"></btn>')
-    const _vm = new Vue({
-      data () {
-        return {
-          msg: {title: 'title', content: 'content'}
-        }
-      },
-      render: res.render,
-      staticRenderFns: res.staticRenderFns
-    }).$mount()
-    await _vm.$nextTick()
-    const trigger = _vm.$el
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    const popover = document.querySelector('.popover')
-    expect(popover).to.exist
-    expect(popover.querySelector('.popover-title').innerText).to.equal('title')
-    expect(popover.querySelector('.popover-content').innerText).to.equal('content')
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    _vm.$destroy()
-  })
-
-  it('should not show popover with no title and content', async () => {
-    const res = Vue.compile('<popover v-model="show"><button data-role="trigger"></button></popover>')
-    const _vm = new Vue({
-      data () {
-        return {
-          show: true
-        }
-      },
-      components: {Popover},
-      render: res.render,
-      staticRenderFns: res.staticRenderFns
-    }).$mount()
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    $(_vm.$el).remove()
-    $('.popover').remove()
-    _vm.$destroy()
-  })
-
-  it('should be able to use custom target', async () => {
-    const res = Vue.compile('<div><button ref="btn" type="button">btn</button><popover :target="btn" trigger="focus" title="123"></popover></div>')
-    const _vm = new Vue({
-      data () {
-        return {
-          btn: null
-        }
-      },
-      mounted () {
-        this.btn = this.$refs.btn
-      },
-      components: {Popover},
-      render: res.render,
-      staticRenderFns: res.staticRenderFns
-    }).$mount()
-    const $el = $(_vm.$el).appendTo('body')
-    await _vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    utils.triggerEvent(_vm.btn, 'focus')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    $el.remove()
-    $('.popover').remove()
-    _vm.$destroy()
-  })
-
-  it('should be able to show popover on click', async () => {
-    const _vm = vm.$refs['popover-example']
     await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to change trigger to manual', async () => {
-    const _vm = vm.$refs['popover-manual-trigger']
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    _vm.show = true
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    _vm.show = false
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able change trigger to hover-focus', async () => {
-    const _vm = vm.$refs['popover-triggers']
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    // matches don't work in here
-    const savedMatches = Element.prototype.matches
-    Element.prototype.matches = () => true
-    const trigger = _vm.$el.querySelectorAll('button')[3]
-    utils.triggerEvent(trigger, 'focus')
-    await utils.sleep(300)
-    Element.prototype.matches = savedMatches
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    utils.triggerEvent(trigger, 'blur')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to change trigger to click', async () => {
-    const _vm = vm.$refs['popover-triggers']
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    const trigger = _vm.$el.querySelectorAll('button')[4]
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to change trigger to hover', async () => {
-    const _vm = vm.$refs['popover-triggers']
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    const trigger = _vm.$el.querySelectorAll('button')[1]
+    const trigger = _vm.$el.querySelector('button')
     utils.triggerEvent(trigger, 'mouseenter')
-    await utils.sleep(300)
+    await utils.sleep(150)
+    // not shown yet
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    await utils.sleep(150)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
     utils.triggerEvent(trigger, 'mouseleave')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to toggle correctly on fast click', async () => {
-    const _vm = vm.$refs['popover-triggers']
-    const button = _vm.$el.querySelectorAll('button')[4]
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    utils.triggerEvent(button, 'click')
-    utils.triggerEvent(button, 'click')
-    utils.triggerEvent(button, 'click')
-    await utils.sleep(300)
+    await utils.sleep(200)
+    // not hidden yet
     expect(document.querySelectorAll('.popover').length).to.equal(1)
-    utils.triggerEvent(button, 'click')
-    utils.triggerEvent(button, 'click')
-    utils.triggerEvent(button, 'click')
-    await utils.sleep(300)
+    await utils.sleep(400)
     expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to change trigger to outside-click', async () => {
-    const _vm = vm.$refs['popover-triggers']
-    const button = _vm.$el.querySelectorAll('button')[0]
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    utils.triggerEvent(button, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    document.body.click()
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to disable', async () => {
-    const _vm = vm.$refs['popover-disable']
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to hide title', async () => {
-    const _vm = vm.$refs['popover-with-empty-title']
-    await vm.$nextTick()
-    const trigger = _vm.$el.querySelector('button')
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    expect(document.querySelector('.popover .popover-title').style.display).to.equal('none')
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to change placement to top', async () => {
-    const _vm = vm.$refs['popover-placements']
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    const trigger = _vm.$el.querySelectorAll('button')[1]
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    const popover = document.querySelector('.popover')
-    expect(popover).to.exist
-    expect(popover.className).to.contain('top')
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to change placement to bottom', async () => {
-    const _vm = vm.$refs['popover-placements']
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    const trigger = _vm.$el.querySelectorAll('button')[2]
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    const popover = document.querySelector('.popover')
-    expect(popover).to.exist
-    expect(popover.className).to.contain('bottom')
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to change placement to left', async () => {
-    const _vm = vm.$refs['popover-placements']
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    const trigger = _vm.$el.querySelectorAll('button')[0]
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    const popover = document.querySelector('.popover')
-    expect(popover).to.exist
-    expect(popover.className).to.contain('left')
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to change placement to right', async () => {
-    const _vm = vm.$refs['popover-placements']
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    const trigger = _vm.$el.querySelectorAll('button')[3]
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    const popover = document.querySelector('.popover')
-    expect(popover).to.exist
-    expect(popover.className).to.contain('right')
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-  })
-
-  it('should be able to change trigger in runtime', async () => {
-    const res = Vue.compile('<popover title="123" :trigger="trigger"><button data-role="trigger"></button></popover>')
-    const _vm = new Vue({
-      data () {
-        return {
-          trigger: 'focus'
-        }
-      },
-      components: {Popover},
-      render: res.render,
-      staticRenderFns: res.staticRenderFns
-    }).$mount()
-    const $el = $(_vm.$el).appendTo('body')
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    await _vm.$nextTick()
-    const trigger = _vm.$el.querySelector('button')
-    utils.triggerEvent(trigger, 'focus')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    _vm.trigger = 'click'
-    await _vm.$nextTick()
-    utils.triggerEvent(trigger, 'blur')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    $el.remove()
     _vm.$destroy()
-  })
-
-  it('should be able to change content in runtime', async () => {
-    const res = Vue.compile('<popover :content="msg" trigger="click"><btn>123</btn></popover>')
-    const vm = new Vue({
-      data () {
-        return {
-          msg: 'text'
-        }
-      },
-      render: res.render,
-      staticRenderFns: res.staticRenderFns
-    }).$mount()
-    const $el = $(vm.$el).appendTo('body')
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    await vm.$nextTick()
-    vm.msg = 'text2'
-    await vm.$nextTick()
-    await vm.$nextTick()
-    const trigger = vm.$el.querySelector('button')
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    expect(document.querySelector('.popover-content').innerText).to.equal('text2')
-    const topBefore = document.querySelector('.popover').style.top
-    vm.msg = 'This is a very very long text. This is a very very long text. This is a very very long text'
-    await vm.$nextTick()
-    expect(document.querySelectorAll('.popover').length).to.equal(1)
-    expect(document.querySelector('.popover-content').innerText).to.contain('This is a very very long text')
-    await vm.$nextTick()
-    const topAfter = document.querySelector('.popover').style.top
-    expect(topAfter).not.equal(topBefore)
-    utils.triggerEvent(trigger, 'click')
-    await utils.sleep(300)
-    expect(document.querySelectorAll('.popover').length).to.equal(0)
-    vm.msg = ''
-    await vm.$nextTick()
-    $el.remove()
-    vm.$destroy()
   })
 })

--- a/test/specs/Popover.spec.js
+++ b/test/specs/Popover.spec.js
@@ -439,4 +439,24 @@ describe('Popover', () => {
     expect(document.querySelectorAll('.popover').length).to.equal(0)
     _vm.$destroy()
   })
+
+  it('should be able to show even when hideDelay < showDelay < transitionDuration ', async function () {
+    const res = Vue.compile('<popover :hideDelay="1" :showDelay="100" :transitionDuration="500" trigger="hover" title="123"><button></button></popover>')
+    const _vm = new Vue({
+      components: {Popover},
+      render: res.render,
+      staticRenderFns: res.staticRenderFns
+    }).$mount()
+    await vm.$nextTick()
+    const trigger = _vm.$el.querySelector('button')
+    utils.triggerEvent(trigger, 'mouseenter')
+    await utils.sleep(200)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    utils.triggerEvent(trigger, 'mouseleave')
+    await utils.sleep(200)
+    utils.triggerEvent(trigger, 'mouseenter')
+    await utils.sleep(600)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    _vm.$destroy()
+  })
 })

--- a/test/specs/Popover.spec.js
+++ b/test/specs/Popover.spec.js
@@ -22,399 +22,399 @@ describe('Popover', () => {
     $('body').css('text-align', '').css('padding-top', '')
   })
 
-  // it('should be ok to render if no trigger present', async () => {
-  //   const Constructor = Vue.extend(Popover)
-  //   const vm = new Constructor().$mount()
-  //   await vm.$nextTick()
-  //   $(vm.$el).remove()
-  //   vm.$destroy()
-  // })
+  it('should be ok to render if no trigger present', async () => {
+    const Constructor = Vue.extend(Popover)
+    const vm = new Constructor().$mount()
+    await vm.$nextTick()
+    $(vm.$el).remove()
+    vm.$destroy()
+  })
 
-  // it('should be able to show popover on init', async () => {
-  //   const res = Vue.compile('<popover v-model="show" title="123"><button data-role="trigger"></button></popover>')
-  //   const _vm = new Vue({
-  //     data () {
-  //       return {
-  //         show: true
-  //       }
-  //     },
-  //     components: {Popover},
-  //     render: res.render,
-  //     staticRenderFns: res.staticRenderFns
-  //   }).$mount()
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   $(_vm.$el).remove()
-  //   $('.popover').remove()
-  //   _vm.$destroy()
-  // })
+  it('should be able to show popover on init', async () => {
+    const res = Vue.compile('<popover v-model="show" title="123"><button data-role="trigger"></button></popover>')
+    const _vm = new Vue({
+      data () {
+        return {
+          show: true
+        }
+      },
+      components: {Popover},
+      render: res.render,
+      staticRenderFns: res.staticRenderFns
+    }).$mount()
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    $(_vm.$el).remove()
+    $('.popover').remove()
+    _vm.$destroy()
+  })
 
-  // it('should be able to use popover directive', async () => {
-  //   const res = Vue.compile('<btn v-popover="msg"></btn>')
-  //   const _vm = new Vue({
-  //     data () {
-  //       return {
-  //         msg: {title: 'title', content: 'content'}
-  //       }
-  //     },
-  //     render: res.render,
-  //     staticRenderFns: res.staticRenderFns
-  //   }).$mount()
-  //   await _vm.$nextTick()
-  //   const trigger = _vm.$el
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   let popover = document.querySelector('.popover')
-  //   expect(popover).to.exist
-  //   expect(popover.querySelector('.popover-title').innerText).to.equal('title')
-  //   expect(popover.querySelector('.popover-content').innerText).to.equal('content')
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   // this should work
-  //   _vm.msg = {title: 'title2', content: 'content2'}
-  //   await _vm.$nextTick()
-  //   await _vm.$nextTick()
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   popover = document.querySelector('.popover')
-  //   expect(popover).to.exist
-  //   expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
-  //   expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   // this should not work
-  //   _vm.$set(_vm.msg, 'title', 'title3')
-  //   await _vm.$nextTick()
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   popover = document.querySelector('.popover')
-  //   expect(popover).to.exist
-  //   expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
-  //   expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
-  //   _vm.$destroy()
-  // })
+  it('should be able to use popover directive', async () => {
+    const res = Vue.compile('<btn v-popover="msg"></btn>')
+    const _vm = new Vue({
+      data () {
+        return {
+          msg: {title: 'title', content: 'content'}
+        }
+      },
+      render: res.render,
+      staticRenderFns: res.staticRenderFns
+    }).$mount()
+    await _vm.$nextTick()
+    const trigger = _vm.$el
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    let popover = document.querySelector('.popover')
+    expect(popover).to.exist
+    expect(popover.querySelector('.popover-title').innerText).to.equal('title')
+    expect(popover.querySelector('.popover-content').innerText).to.equal('content')
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    // this should work
+    _vm.msg = {title: 'title2', content: 'content2'}
+    await _vm.$nextTick()
+    await _vm.$nextTick()
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    popover = document.querySelector('.popover')
+    expect(popover).to.exist
+    expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
+    expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    // this should not work
+    _vm.$set(_vm.msg, 'title', 'title3')
+    await _vm.$nextTick()
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    popover = document.querySelector('.popover')
+    expect(popover).to.exist
+    expect(popover.querySelector('.popover-title').innerText).to.equal('title2')
+    expect(popover.querySelector('.popover-content').innerText).to.equal('content2')
+    _vm.$destroy()
+  })
 
-  // it('directive with invalid modifiers should be ok', async () => {
-  //   // invalid modifier should be ok
-  //   const res = Vue.compile('<btn v-popover.test1.test2="msg"></btn>')
-  //   const _vm = new Vue({
-  //     data () {
-  //       return {
-  //         msg: {title: 'title', content: 'content'}
-  //       }
-  //     },
-  //     render: res.render,
-  //     staticRenderFns: res.staticRenderFns
-  //   }).$mount()
-  //   await _vm.$nextTick()
-  //   const trigger = _vm.$el
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   const popover = document.querySelector('.popover')
-  //   expect(popover).to.exist
-  //   expect(popover.querySelector('.popover-title').innerText).to.equal('title')
-  //   expect(popover.querySelector('.popover-content').innerText).to.equal('content')
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   _vm.$destroy()
-  // })
+  it('directive with invalid modifiers should be ok', async () => {
+    // invalid modifier should be ok
+    const res = Vue.compile('<btn v-popover.test1.test2="msg"></btn>')
+    const _vm = new Vue({
+      data () {
+        return {
+          msg: {title: 'title', content: 'content'}
+        }
+      },
+      render: res.render,
+      staticRenderFns: res.staticRenderFns
+    }).$mount()
+    await _vm.$nextTick()
+    const trigger = _vm.$el
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    const popover = document.querySelector('.popover')
+    expect(popover).to.exist
+    expect(popover.querySelector('.popover-title').innerText).to.equal('title')
+    expect(popover.querySelector('.popover-content').innerText).to.equal('content')
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    _vm.$destroy()
+  })
 
-  // it('should not show popover with no title and content', async () => {
-  //   const res = Vue.compile('<popover v-model="show"><button data-role="trigger"></button></popover>')
-  //   const _vm = new Vue({
-  //     data () {
-  //       return {
-  //         show: true
-  //       }
-  //     },
-  //     components: {Popover},
-  //     render: res.render,
-  //     staticRenderFns: res.staticRenderFns
-  //   }).$mount()
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   $(_vm.$el).remove()
-  //   $('.popover').remove()
-  //   _vm.$destroy()
-  // })
+  it('should not show popover with no title and content', async () => {
+    const res = Vue.compile('<popover v-model="show"><button data-role="trigger"></button></popover>')
+    const _vm = new Vue({
+      data () {
+        return {
+          show: true
+        }
+      },
+      components: {Popover},
+      render: res.render,
+      staticRenderFns: res.staticRenderFns
+    }).$mount()
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    $(_vm.$el).remove()
+    $('.popover').remove()
+    _vm.$destroy()
+  })
 
-  // it('should be able to use custom target', async () => {
-  //   const res = Vue.compile('<div><button ref="btn" type="button">btn</button><popover :target="btn" trigger="focus" title="123"></popover></div>')
-  //   const _vm = new Vue({
-  //     data () {
-  //       return {
-  //         btn: null
-  //       }
-  //     },
-  //     mounted () {
-  //       this.btn = this.$refs.btn
-  //     },
-  //     components: {Popover},
-  //     render: res.render,
-  //     staticRenderFns: res.staticRenderFns
-  //   }).$mount()
-  //   const $el = $(_vm.$el).appendTo('body')
-  //   await _vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   utils.triggerEvent(_vm.btn, 'focus')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   $el.remove()
-  //   $('.popover').remove()
-  //   _vm.$destroy()
-  // })
+  it('should be able to use custom target', async () => {
+    const res = Vue.compile('<div><button ref="btn" type="button">btn</button><popover :target="btn" trigger="focus" title="123"></popover></div>')
+    const _vm = new Vue({
+      data () {
+        return {
+          btn: null
+        }
+      },
+      mounted () {
+        this.btn = this.$refs.btn
+      },
+      components: {Popover},
+      render: res.render,
+      staticRenderFns: res.staticRenderFns
+    }).$mount()
+    const $el = $(_vm.$el).appendTo('body')
+    await _vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    utils.triggerEvent(_vm.btn, 'focus')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    $el.remove()
+    $('.popover').remove()
+    _vm.$destroy()
+  })
 
-  // it('should be able to show popover on click', async () => {
-  //   const _vm = vm.$refs['popover-example']
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to show popover on click', async () => {
+    const _vm = vm.$refs['popover-example']
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to change trigger to manual', async () => {
-  //   const _vm = vm.$refs['popover-manual-trigger']
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   _vm.show = true
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   _vm.show = false
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to change trigger to manual', async () => {
+    const _vm = vm.$refs['popover-manual-trigger']
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    _vm.show = true
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    _vm.show = false
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able change trigger to hover-focus', async () => {
-  //   const _vm = vm.$refs['popover-triggers']
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   // matches don't work in here
-  //   const savedMatches = Element.prototype.matches
-  //   Element.prototype.matches = () => true
-  //   const trigger = _vm.$el.querySelectorAll('button')[3]
-  //   utils.triggerEvent(trigger, 'focus')
-  //   await utils.sleep(300)
-  //   Element.prototype.matches = savedMatches
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   utils.triggerEvent(trigger, 'blur')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able change trigger to hover-focus', async () => {
+    const _vm = vm.$refs['popover-triggers']
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    // matches don't work in here
+    const savedMatches = Element.prototype.matches
+    Element.prototype.matches = () => true
+    const trigger = _vm.$el.querySelectorAll('button')[3]
+    utils.triggerEvent(trigger, 'focus')
+    await utils.sleep(300)
+    Element.prototype.matches = savedMatches
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    utils.triggerEvent(trigger, 'blur')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to change trigger to click', async () => {
-  //   const _vm = vm.$refs['popover-triggers']
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   const trigger = _vm.$el.querySelectorAll('button')[4]
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to change trigger to click', async () => {
+    const _vm = vm.$refs['popover-triggers']
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    const trigger = _vm.$el.querySelectorAll('button')[4]
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to change trigger to hover', async () => {
-  //   const _vm = vm.$refs['popover-triggers']
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   const trigger = _vm.$el.querySelectorAll('button')[1]
-  //   utils.triggerEvent(trigger, 'mouseenter')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   utils.triggerEvent(trigger, 'mouseleave')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to change trigger to hover', async () => {
+    const _vm = vm.$refs['popover-triggers']
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    const trigger = _vm.$el.querySelectorAll('button')[1]
+    utils.triggerEvent(trigger, 'mouseenter')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    utils.triggerEvent(trigger, 'mouseleave')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to toggle correctly on fast click', async () => {
-  //   const _vm = vm.$refs['popover-triggers']
-  //   const button = _vm.$el.querySelectorAll('button')[4]
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   utils.triggerEvent(button, 'click')
-  //   utils.triggerEvent(button, 'click')
-  //   utils.triggerEvent(button, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   utils.triggerEvent(button, 'click')
-  //   utils.triggerEvent(button, 'click')
-  //   utils.triggerEvent(button, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to toggle correctly on fast click', async () => {
+    const _vm = vm.$refs['popover-triggers']
+    const button = _vm.$el.querySelectorAll('button')[4]
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
+    utils.triggerEvent(button, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to change trigger to outside-click', async () => {
-  //   const _vm = vm.$refs['popover-triggers']
-  //   const button = _vm.$el.querySelectorAll('button')[0]
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   utils.triggerEvent(button, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   document.body.click()
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to change trigger to outside-click', async () => {
+    const _vm = vm.$refs['popover-triggers']
+    const button = _vm.$el.querySelectorAll('button')[0]
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    utils.triggerEvent(button, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    document.body.click()
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to disable', async () => {
-  //   const _vm = vm.$refs['popover-disable']
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to disable', async () => {
+    const _vm = vm.$refs['popover-disable']
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    utils.triggerEvent(_vm.$el.querySelector('button'), 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to hide title', async () => {
-  //   const _vm = vm.$refs['popover-with-empty-title']
-  //   await vm.$nextTick()
-  //   const trigger = _vm.$el.querySelector('button')
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   expect(document.querySelector('.popover .popover-title').style.display).to.equal('none')
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to hide title', async () => {
+    const _vm = vm.$refs['popover-with-empty-title']
+    await vm.$nextTick()
+    const trigger = _vm.$el.querySelector('button')
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    expect(document.querySelector('.popover .popover-title').style.display).to.equal('none')
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to change placement to top', async () => {
-  //   const _vm = vm.$refs['popover-placements']
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   const trigger = _vm.$el.querySelectorAll('button')[1]
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   const popover = document.querySelector('.popover')
-  //   expect(popover).to.exist
-  //   expect(popover.className).to.contain('top')
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to change placement to top', async () => {
+    const _vm = vm.$refs['popover-placements']
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    const trigger = _vm.$el.querySelectorAll('button')[1]
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    const popover = document.querySelector('.popover')
+    expect(popover).to.exist
+    expect(popover.className).to.contain('top')
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to change placement to bottom', async () => {
-  //   const _vm = vm.$refs['popover-placements']
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   const trigger = _vm.$el.querySelectorAll('button')[2]
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   const popover = document.querySelector('.popover')
-  //   expect(popover).to.exist
-  //   expect(popover.className).to.contain('bottom')
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to change placement to bottom', async () => {
+    const _vm = vm.$refs['popover-placements']
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    const trigger = _vm.$el.querySelectorAll('button')[2]
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    const popover = document.querySelector('.popover')
+    expect(popover).to.exist
+    expect(popover.className).to.contain('bottom')
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to change placement to left', async () => {
-  //   const _vm = vm.$refs['popover-placements']
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   const trigger = _vm.$el.querySelectorAll('button')[0]
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   const popover = document.querySelector('.popover')
-  //   expect(popover).to.exist
-  //   expect(popover.className).to.contain('left')
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to change placement to left', async () => {
+    const _vm = vm.$refs['popover-placements']
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    const trigger = _vm.$el.querySelectorAll('button')[0]
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    const popover = document.querySelector('.popover')
+    expect(popover).to.exist
+    expect(popover.className).to.contain('left')
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to change placement to right', async () => {
-  //   const _vm = vm.$refs['popover-placements']
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   const trigger = _vm.$el.querySelectorAll('button')[3]
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   const popover = document.querySelector('.popover')
-  //   expect(popover).to.exist
-  //   expect(popover.className).to.contain('right')
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  // })
+  it('should be able to change placement to right', async () => {
+    const _vm = vm.$refs['popover-placements']
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    const trigger = _vm.$el.querySelectorAll('button')[3]
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    const popover = document.querySelector('.popover')
+    expect(popover).to.exist
+    expect(popover.className).to.contain('right')
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+  })
 
-  // it('should be able to change trigger in runtime', async () => {
-  //   const res = Vue.compile('<popover title="123" :trigger="trigger"><button data-role="trigger"></button></popover>')
-  //   const _vm = new Vue({
-  //     data () {
-  //       return {
-  //         trigger: 'focus'
-  //       }
-  //     },
-  //     components: {Popover},
-  //     render: res.render,
-  //     staticRenderFns: res.staticRenderFns
-  //   }).$mount()
-  //   const $el = $(_vm.$el).appendTo('body')
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   await _vm.$nextTick()
-  //   const trigger = _vm.$el.querySelector('button')
-  //   utils.triggerEvent(trigger, 'focus')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   _vm.trigger = 'click'
-  //   await _vm.$nextTick()
-  //   utils.triggerEvent(trigger, 'blur')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   $el.remove()
-  //   _vm.$destroy()
-  // })
+  it('should be able to change trigger in runtime', async () => {
+    const res = Vue.compile('<popover title="123" :trigger="trigger"><button data-role="trigger"></button></popover>')
+    const _vm = new Vue({
+      data () {
+        return {
+          trigger: 'focus'
+        }
+      },
+      components: {Popover},
+      render: res.render,
+      staticRenderFns: res.staticRenderFns
+    }).$mount()
+    const $el = $(_vm.$el).appendTo('body')
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    await _vm.$nextTick()
+    const trigger = _vm.$el.querySelector('button')
+    utils.triggerEvent(trigger, 'focus')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    _vm.trigger = 'click'
+    await _vm.$nextTick()
+    utils.triggerEvent(trigger, 'blur')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    $el.remove()
+    _vm.$destroy()
+  })
 
-  // it('should be able to change content in runtime', async () => {
-  //   const res = Vue.compile('<popover :content="msg" trigger="click"><btn>123</btn></popover>')
-  //   const vm = new Vue({
-  //     data () {
-  //       return {
-  //         msg: 'text'
-  //       }
-  //     },
-  //     render: res.render,
-  //     staticRenderFns: res.staticRenderFns
-  //   }).$mount()
-  //   const $el = $(vm.$el).appendTo('body')
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   await vm.$nextTick()
-  //   vm.msg = 'text2'
-  //   await vm.$nextTick()
-  //   await vm.$nextTick()
-  //   const trigger = vm.$el.querySelector('button')
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   expect(document.querySelector('.popover-content').innerText).to.equal('text2')
-  //   const topBefore = document.querySelector('.popover').style.top
-  //   vm.msg = 'This is a very very long text. This is a very very long text. This is a very very long text'
-  //   await vm.$nextTick()
-  //   expect(document.querySelectorAll('.popover').length).to.equal(1)
-  //   expect(document.querySelector('.popover-content').innerText).to.contain('This is a very very long text')
-  //   await vm.$nextTick()
-  //   const topAfter = document.querySelector('.popover').style.top
-  //   expect(topAfter).not.equal(topBefore)
-  //   utils.triggerEvent(trigger, 'click')
-  //   await utils.sleep(300)
-  //   expect(document.querySelectorAll('.popover').length).to.equal(0)
-  //   vm.msg = ''
-  //   await vm.$nextTick()
-  //   $el.remove()
-  //   vm.$destroy()
-  // })
+  it('should be able to change content in runtime', async () => {
+    const res = Vue.compile('<popover :content="msg" trigger="click"><btn>123</btn></popover>')
+    const vm = new Vue({
+      data () {
+        return {
+          msg: 'text'
+        }
+      },
+      render: res.render,
+      staticRenderFns: res.staticRenderFns
+    }).$mount()
+    const $el = $(vm.$el).appendTo('body')
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    await vm.$nextTick()
+    vm.msg = 'text2'
+    await vm.$nextTick()
+    await vm.$nextTick()
+    const trigger = vm.$el.querySelector('button')
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    expect(document.querySelector('.popover-content').innerText).to.equal('text2')
+    const topBefore = document.querySelector('.popover').style.top
+    vm.msg = 'This is a very very long text. This is a very very long text. This is a very very long text'
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).to.equal(1)
+    expect(document.querySelector('.popover-content').innerText).to.contain('This is a very very long text')
+    await vm.$nextTick()
+    const topAfter = document.querySelector('.popover').style.top
+    expect(topAfter).not.equal(topBefore)
+    utils.triggerEvent(trigger, 'click')
+    await utils.sleep(300)
+    expect(document.querySelectorAll('.popover').length).to.equal(0)
+    vm.msg = ''
+    await vm.$nextTick()
+    $el.remove()
+    vm.$destroy()
+  })
 
   it('should be able to show/hide on specified delay', async function () {
     const res = Vue.compile('<popover :showDelay="300" :hideDelay="400" trigger="hover" title="123"><button></button></popover>')

--- a/test/specs/Popover.spec.js
+++ b/test/specs/Popover.spec.js
@@ -432,7 +432,7 @@ describe('Popover', () => {
     await utils.sleep(150)
     expect(document.querySelectorAll('.popover').length).to.equal(1)
     utils.triggerEvent(trigger, 'mouseleave')
-    await utils.sleep(200)
+    await utils.sleep(300)
     // not hidden yet
     expect(document.querySelectorAll('.popover').length).to.equal(1)
     await utils.sleep(400)


### PR DESCRIPTION
### Is this a bug fix or enhancement?

Enhancement.

### Is there a related issue?

I want to make possible to set an delay to show/hide a popover. Just like the [Bootstrap Tooltip](https://getbootstrap.com/docs/4.2/components/tooltips/).

It can be very annoying being unable to set in cases like tables, where you have all the cells around also wrapped in a popover. If you hover really fast from on side to the other of the table you will be unable to see some cells as the popover is shown the moment you hover one on it side.

Let me know if you don't get it. I can add screenshots later.

### Any Breaking changes?

Yes. Thought, I can work around it, by not removing `transitionDuration` for now. 

----

Please let me know if it sounds like something for you, so that I can work on it better - with your help - and also write tests.

We use all over the client where I work, and we would be pretty much interested in having it merged.