### PR TITLE
Model Backdrop was "click", now "mousedown"

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -1,5 +1,5 @@
 <template>
-  <div tabindex="-1" role="dialog" class="modal" :class="{fade:transitionDuration>0}" @click.self="backdropClicked">
+  <div tabindex="-1" role="dialog" class="modal" :class="{fade:transitionDuration>0}" @mousedown.self="backdropClicked">
     <div ref="dialog" class="modal-dialog" :class="modalSizeClass" role="document">
       <div class="modal-content">
         <div class="modal-header" v-if="header">

--- a/test/specs/MessageBox.spec.js
+++ b/test/specs/MessageBox.spec.js
@@ -279,6 +279,8 @@ describe('MessageBox', () => {
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(document.querySelector('.modal').className).to.contain('in')
+    utils.triggerEvent(document.querySelector('.modal'), 'mousedown')
+    utils.triggerEvent(document.querySelector('.modal'), 'mouseup')
     utils.triggerEvent(document.querySelector('.modal'), 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).not.exist

--- a/test/specs/Modal.spec.js
+++ b/test/specs/Modal.spec.js
@@ -379,6 +379,8 @@ describe('Modal', () => {
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
+    utils.triggerEvent(modal, 'mousedown')
+    utils.triggerEvent(modal, 'mouseup')
     utils.triggerEvent(modal, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).not.exist
@@ -395,6 +397,8 @@ describe('Modal', () => {
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist
     expect(modal.className).to.contain('in')
+    utils.triggerEvent(modal, 'mousedown')
+    utils.triggerEvent(modal, 'mouseup')
     utils.triggerEvent(modal, 'click')
     await utils.sleep(utils.transitionDuration)
     expect(document.querySelector('.modal-backdrop')).to.exist


### PR DESCRIPTION
As mentioned in #285 when someone starts a click event inside the modal content area, and then releases it outside, in the backdrop, the modal hides. This is a frustrating issue when selecting text in the modal, as I often do. This only happens in chrome and is also an issue in bootstrap jquery itself. 

This is the simplest possible fix - replacing @click.self with @mousedown.self. This avoids the weird chrome behaviour.

This does change the timing of the dismissal. Are any users relying on their own @mouseup or @mousedown events firing before the backdrop event? I think that none are.
