### PR TITLE
fix: popover opening with new slot syntax and no title/content

### DIFF
--- a/src/components/popover/Popover.js
+++ b/src/components/popover/Popover.js
@@ -60,7 +60,7 @@ export default {
   },
   methods: {
     isNotEmpty() {
-      return this.title || this.content || this.$slots.popover
+      return this.title || this.content || this.$scopedSlots.popover
     },
   },
 }

--- a/src/components/popover/Popover.spec.js
+++ b/src/components/popover/Popover.spec.js
@@ -608,4 +608,31 @@ This is a very very long text. This is a very very long text. This is a very ver
     await sleep(600)
     expect(document.querySelectorAll('.popover').length).toEqual(1)
   })
+
+  it('should be able to open popover programmatically with vue latest slot syntax and without title and content passed', async () => {
+    const wrapper = createWrapper(
+      `
+          <div>
+            <popover v-model="show">
+              <btn type="primary" id="btn">Popover</btn>
+              <template #popover>
+                <h1>Hello world!</h1>
+              </template>
+            </popover>
+          </div>
+        `,
+      {
+        show: false,
+      }
+    )
+    const vm = wrapper.vm
+    await vm.$nextTick()
+    expect(document.querySelectorAll('.popover').length).toEqual(0)
+    vm.show = true
+    await sleep(300)
+    expect(document.querySelectorAll('.popover').length).toEqual(1)
+    vm.show = false
+    await sleep(300)
+    expect(document.querySelectorAll('.popover').length).toEqual(0)
+  })
 })


### PR DESCRIPTION
### Is this a bug fix or enhancement? - bug fix
Hello again! 👋

Once again, I appreciate all the hard work that's gone into this project. We're still happily using version 1. 😊

As we transitioned away from [deprecated Vue slot syntax](https://eslint.vuejs.org/rules/no-deprecated-slot-attribute.html), we discovered some nuances with the popover component. 

#### The Fix
The issue revolved around the `isNotEmpty` method. Previously, it checked for `this.$slots.popover`, which was causing problems with the latest Vue slot syntax. To address this, I've updated it to `this.$scopedSlots.popover`. This ensures that the popover functions as expected with the updated syntax. I've also added a unit test to cover this specific use case.

### Is there a related issue?
None at this time.

### Any Breaking Changes?
No breaking changes are introduced by this PR.