### PR TITLE
ci: avoid duplicate CI runs on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,12 @@
 name: lint and test
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - dev
+      - master
+      - main
+  pull_request:
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

The workflow `.github/workflows/main.yml` was triggered by both `push` and `pull_request` events. For same-repository PRs (e.g. Renovate branches like #900), every push to the PR branch triggers two identical workflow runs — one for the `push` event and one for the `pull_request` (`synchronize`) event.

This change limits the `push` trigger to the main branches (`dev`, `master`, `main`), so PR branches are only tested via the `pull_request` event, while direct pushes to main branches still run CI.

## Example

Before (PR #900): each job ran twice — [run #253 (push)](https://github.com/wxsms/uiv/actions/runs/34318796249) + [run #254 (pull_request)](https://github.com/wsms/uiv/actions/runs/34318799198).

After: only one run per push.