### PR TITLE
chore: inject VitePress base via env var, keep local dev on default base

### DIFF
--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -23,6 +23,8 @@ jobs:
           run_install: true
       - name: Build
         run: pnpm run docs:build
+        env:
+          VITEPRESS_BASE: /uiv/
       - name: GitHub Pages
         uses: crazy-max/ghaction-github-pages@v5.0.0
         env:

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
   title: 'uiv',
   description: 'Bootstrap 3 components implemented by Vue.',
 
-  base: '/uiv/',
+  // Sub-path base is only needed when deploying to GitHub Pages; it is
+  // injected via VITEPRESS_BASE in the deploy workflow. Local dev/build
+  // defaults to '/'.
+  base: process.env.VITEPRESS_BASE || '/',
   lastUpdated: true,
 
   head: [


### PR DESCRIPTION
## Summary

Follow-up to the sub-path migration: the `base: '/uiv/'` is now injected via the `VITEPRESS_BASE` env var **only in the deploy workflow**. Local dev/build keeps the default `/`, so previewing the docs locally no longer requires the sub-path.

Verified locally:
- default build → `src="/assets/image/logo.png"`
- `VITEPRESS_BASE=/uiv/` build → `src="/uiv/assets/image/logo.png"`

## Test plan
- [ ] CI (lint/test/dist/docs) passes
- [ ] After merge, deployed site still serves assets under `/uiv/`